### PR TITLE
Change in command handling

### DIFF
--- a/csw-cluster-seed/src/test/scala/csw/apps/clusterseed/components/GalilComponentHandlers.scala
+++ b/csw-cluster-seed/src/test/scala/csw/apps/clusterseed/components/GalilComponentHandlers.scala
@@ -8,6 +8,7 @@ import csw.messages.RunningMessage.DomainMessage
 import csw.messages._
 import csw.messages.ccs.Validation
 import csw.messages.ccs.Validations.Valid
+import csw.messages.ccs.commands.ControlCommand
 import csw.messages.framework.ComponentInfo
 import csw.messages.location.TrackingEvent
 import csw.messages.params.states.CurrentState
@@ -42,6 +43,9 @@ class GalilComponentHandlers(
   override def onSetup(commandMessage: CommandMessage): Validation = Valid
 
   override def onObserve(commandMessage: CommandMessage): Validation = Valid
+
+  override def onSubmit(controlCommand: ControlCommand, replyTo: ActorRef[CommandResponse]): Validation = Valid
+  override def onOneway(controlCommand: ControlCommand): Validation = Valid
 
   override def onShutdown(): Future[Unit] = Future.successful(())
 

--- a/csw-framework/src/main/scala/csw/framework/internal/component/ComponentBehavior.scala
+++ b/csw-framework/src/main/scala/csw/framework/internal/component/ComponentBehavior.scala
@@ -161,18 +161,14 @@ class ComponentBehavior[Msg <: DomainMessage: ClassTag](
    * @param commandMessage  Message encapsulating a [[csw.messages.ccs.commands.Command]]
    */
   def onRunningCompCommandMessage(commandMessage: CommandMessage): Unit = {
-    val newMessage: CommandMessage = commandMessage match {
-      case x: Oneway ⇒ x.copy(replyTo = ctx.spawnAnonymous(Actor.ignore))
-      case x: Submit ⇒ x
-    }
 
-    val validation = newMessage.command match {
-      case _: Setup =>
-        log.info(s"Invoking lifecycle handler's onSetup hook with msg :[$newMessage]")
-        lifecycleHandlers.onSetup(newMessage)
-      case _: Observe =>
-        log.info(s"Invoking lifecycle handler's onObserve hook with msg :[$newMessage]")
-        lifecycleHandlers.onObserve(newMessage)
+    val validation = commandMessage match {
+      case _: Oneway =>
+        log.info(s"Invoking lifecycle handler's onOneway hook with msg :[$commandMessage]")
+        lifecycleHandlers.onOneway(commandMessage.command)
+      case _: Submit =>
+        log.info(s"Invoking lifecycle handler's onSubmit hook with msg :[$commandMessage]")
+        lifecycleHandlers.onSubmit(commandMessage.command, commandMessage.replyTo)
     }
 
     val validationCommandResult = CommandValidationResponse.validationAsCommandStatus(validation)

--- a/csw-framework/src/main/scala/csw/framework/scaladsl/ComponentHandlers.scala
+++ b/csw-framework/src/main/scala/csw/framework/scaladsl/ComponentHandlers.scala
@@ -1,14 +1,17 @@
 package csw.framework.scaladsl
 
+import javax.naming.ldap.Control
+
 import akka.typed.ActorRef
 import akka.typed.scaladsl.ActorContext
 import csw.messages.PubSub.PublisherMessage
 import csw.messages.RunningMessage.DomainMessage
 import csw.messages.ccs.Validation
+import csw.messages.ccs.commands.ControlCommand
 import csw.messages.framework.ComponentInfo
 import csw.messages.location.TrackingEvent
 import csw.messages.params.states.CurrentState
-import csw.messages.{CommandMessage, ComponentMessage}
+import csw.messages.{CommandMessage, CommandResponse, ComponentMessage}
 import csw.services.location.scaladsl.LocationService
 
 import scala.concurrent.Future
@@ -27,6 +30,8 @@ abstract class ComponentHandlers[Msg <: DomainMessage: ClassTag](
   def onDomainMsg(msg: Msg): Unit
   def onSetup(commandMessage: CommandMessage): Validation
   def onObserve(commandMessage: CommandMessage): Validation
+  def onSubmit(controlCommand: ControlCommand, replyTo: ActorRef[CommandResponse]): Validation
+  def onOneway(controlCommand: ControlCommand): Validation
   def onShutdown(): Future[Unit]
   def onGoOffline(): Unit
   def onGoOnline(): Unit

--- a/csw-framework/src/test/java/csw/framework/javadsl/components/JSampleComponentHandlers.java
+++ b/csw-framework/src/test/java/csw/framework/javadsl/components/JSampleComponentHandlers.java
@@ -6,11 +6,13 @@ import akka.typed.javadsl.ActorContext;
 import csw.common.components.SampleComponentState;
 import csw.framework.javadsl.JComponentHandlers;
 import csw.messages.CommandMessage;
+import csw.messages.CommandResponse;
 import csw.messages.ComponentMessage;
 import csw.messages.PubSub;
 import csw.messages.ccs.Validation;
 import csw.messages.ccs.ValidationIssue;
 import csw.messages.ccs.Validations;
+import csw.messages.ccs.commands.ControlCommand;
 import csw.messages.framework.ComponentInfo;
 import csw.messages.location.TrackingEvent;
 import csw.messages.params.states.CurrentState;
@@ -82,6 +84,16 @@ public class JSampleComponentHandlers extends JComponentHandlers<JComponentDomai
         pubSubRef.tell(publish);
 
         return validateCommand(commandMessage);
+    }
+
+    @Override
+    public Validation onSubmit(ControlCommand commandMessage, ActorRef<CommandResponse> actorRef) {
+        return Validations.JValid();
+    }
+
+    @Override
+    public Validation onOneway(ControlCommand commandMessage) {
+        return Validations.JValid();
     }
 
     private Validation validateCommand(CommandMessage commandMsg) {

--- a/csw-framework/src/test/scala/csw/common/components/SampleComponentHandlers.scala
+++ b/csw-framework/src/test/scala/csw/common/components/SampleComponentHandlers.scala
@@ -7,6 +7,7 @@ import csw.messages.CommandMessage.{Oneway, Submit}
 import csw.messages.PubSub.{Publish, PublisherMessage}
 import csw.messages._
 import csw.messages.ccs.ValidationIssue.OtherIssue
+import csw.messages.ccs.commands.ControlCommand
 import csw.messages.ccs.{Validation, Validations}
 import csw.messages.framework.ComponentInfo
 import csw.messages.location.{LocationRemoved, LocationUpdated, TrackingEvent}
@@ -89,6 +90,10 @@ class SampleComponentHandlers(
     pubSubRef ! Publish(CurrentState(prefix, Set(choiceKey.set(observeConfigChoice))))
     validateCommand(commandMessage)
   }
+
+  override def onSubmit(controlCommand: ControlCommand, replyTo: ActorRef[CommandResponse]): Validation = Validations.Valid
+  override def onOneway(controlCommand: ControlCommand): Validation = Validations.Valid
+
 
   private def validateCommand(commandMsg: CommandMessage): Validation = {
     commandMsg match {

--- a/csw-vslice/src/main/scala/csw/trombone/assembly/actors/TromboneAssemblyHandlers.scala
+++ b/csw-vslice/src/main/scala/csw/trombone/assembly/actors/TromboneAssemblyHandlers.scala
@@ -6,7 +6,7 @@ import csw.framework.scaladsl.{ComponentBehaviorFactory, ComponentHandlers}
 import csw.messages.PubSub.PublisherMessage
 import csw.messages._
 import csw.messages.ccs.Validations.Valid
-import csw.messages.ccs.commands.Setup
+import csw.messages.ccs.commands.{ControlCommand, Setup}
 import csw.messages.ccs.{Validation, Validations}
 import csw.messages.framework.ComponentInfo
 import csw.messages.location._
@@ -84,6 +84,9 @@ class TromboneAssemblyHandlers(
   }
 
   override def onObserve(commandMessage: CommandMessage): Validations.Valid.type = Validations.Valid
+
+  override def onSubmit(controlCommand: ControlCommand, replyTo: ActorRef[CommandResponse]): Validation = Validations.Valid
+  override def onOneway(controlCommand: ControlCommand): Validation = Validations.Valid
 
   private def getAssemblyConfigs: Future[(TromboneCalculationConfig, TromboneControlConfig)] = ???
 

--- a/csw-vslice/src/main/scala/csw/trombone/hcd/actors/TromboneHcdHandlers.scala
+++ b/csw-vslice/src/main/scala/csw/trombone/hcd/actors/TromboneHcdHandlers.scala
@@ -8,9 +8,9 @@ import akka.util.Timeout
 import csw.framework.scaladsl.{ComponentBehaviorFactory, ComponentHandlers}
 import csw.messages.PubSub.PublisherMessage
 import csw.messages._
-import csw.messages.ccs.Validation
+import csw.messages.ccs.{Validation, Validations}
 import csw.messages.ccs.Validations.Valid
-import csw.messages.ccs.commands.{Observe, Setup}
+import csw.messages.ccs.commands.{ControlCommand, Observe, Setup}
 import csw.messages.framework.ComponentInfo
 import csw.messages.location.TrackingEvent
 import csw.messages.params.models.Units.encoder
@@ -94,6 +94,10 @@ class TromboneHcdHandlers(
       case x => println(s"Unknown config key $x")
     }
   }
+
+  override def onSubmit(controlCommand: ControlCommand, replyTo: ActorRef[CommandResponse]): Validation = Validations.Valid
+  override def onOneway(controlCommand: ControlCommand): Validation = Validations.Valid
+
 
   def onDomainMsg(tromboneMsg: TromboneMessage): Unit = tromboneMsg match {
     case x: TromboneEngineering => onEngMsg(x)


### PR DESCRIPTION
Kim and I have decided that the handling of onObserve and onSetup should be replaced by the handling of onSubmit and onOneway.  We have made some changes to this effect in this branch.  We have not removed the onObserve and onSetup methods, but they should be removed if you agree with our changes in this PR.  We can discuss here, or in Slack, or in the next Tech Huddle on Tuesday.