### PR TITLE
This commit provides a PubSub[T,U] version that allows subscribeOnly …

### DIFF
--- a/csw-command/src/main/scala/csw/services/command/javadsl/JCommandService.scala
+++ b/csw-command/src/main/scala/csw/services/command/javadsl/JCommandService.scala
@@ -14,7 +14,7 @@ import csw.messages.commands.matchers.StateMatcher
 import csw.messages.commands.{CommandResponse, ControlCommand}
 import csw.messages.location.AkkaLocation
 import csw.messages.params.models.Id
-import csw.messages.params.states.CurrentState
+import csw.messages.params.states.{CurrentState, StateName}
 import csw.services.command.scaladsl.{CommandService, CurrentStateSubscription}
 
 import scala.collection.JavaConverters.iterableAsScalaIterableConverter
@@ -161,7 +161,7 @@ class JCommandService(akkaLocation: AkkaLocation, actorSystem: ActorSystem[_]) {
    * @return a CurrentStateSubscription to stop the subscription
    */
   def subscribeOnlyCurrentState(
-      names: java.util.Set[String],
+      names: java.util.Set[StateName],
       callback: Consumer[CurrentState]
   ): CurrentStateSubscription =
     sCommandService.subscribeOnlyCurrentState(names.asScala.toSet, callback.asScala)

--- a/csw-command/src/main/scala/csw/services/command/scaladsl/CommandService.scala
+++ b/csw-command/src/main/scala/csw/services/command/scaladsl/CommandService.scala
@@ -15,7 +15,7 @@ import csw.messages.commands.matchers.{Matcher, StateMatcher}
 import csw.messages.commands.{CommandResponse, ControlCommand}
 import csw.messages.location.AkkaLocation
 import csw.messages.params.models.Id
-import csw.messages.params.states.CurrentState
+import csw.messages.params.states.{CurrentState, StateName}
 import csw.messages.{CommandResponseManagerMessage, ComponentMessage}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -178,7 +178,7 @@ class CommandService(componentLocation: AkkaLocation)(implicit val actorSystem: 
    * @return a CurrentStateSubscription to stop the subscription
    */
   def subscribeOnlyCurrentState(
-      names: Set[String],
+      names: Set[StateName],
       callback: CurrentState ⇒ Unit
   ): CurrentStateSubscription =
     new CurrentStateSubscription(component, Some(names), callback)

--- a/csw-command/src/main/scala/csw/services/command/scaladsl/CurrentStateSubscription.scala
+++ b/csw-command/src/main/scala/csw/services/command/scaladsl/CurrentStateSubscription.scala
@@ -6,7 +6,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.{KillSwitches, Materializer, OverflowStrategy}
 import csw.messages.ComponentCommonMessage.ComponentStateSubscription
 import csw.messages.framework.PubSub.{Subscribe, SubscribeOnly}
-import csw.messages.params.states.CurrentState
+import csw.messages.params.states.{CurrentState, StateName}
 
 /**
  * The handle to the subscription created for the current state published by the specified publisher
@@ -17,7 +17,7 @@ import csw.messages.params.states.CurrentState
  */
 class CurrentStateSubscription private[command] (
     publisher: ActorRef[ComponentStateSubscription],
-    names: Option[Set[String]],
+    names: Option[Set[StateName]],
     callback: CurrentState ⇒ Unit
 )(implicit val mat: Materializer) {
 

--- a/csw-framework/src/main/scala/csw/framework/CurrentStatePublisher.scala
+++ b/csw-framework/src/main/scala/csw/framework/CurrentStatePublisher.scala
@@ -2,14 +2,14 @@ package csw.framework
 
 import akka.actor.typed.ActorRef
 import csw.messages.framework.PubSub.{Publish, PublisherMessage}
-import csw.messages.params.states.CurrentState
+import csw.messages.params.states.{CurrentState, StateName}
 
 /**
  * Wrapper API for publishing [[csw.messages.params.states.CurrentState]] of a component
  *
  * @param publisherActor the wrapped actor
  */
-class CurrentStatePublisher private[framework] (publisherActor: ActorRef[PublisherMessage[CurrentState]]) {
+class CurrentStatePublisher private[framework] (publisherActor: ActorRef[PublisherMessage[CurrentState, StateName]]) {
 
   /**
    * Publish [[csw.messages.params.states.CurrentState]] to the subscribed components

--- a/csw-framework/src/main/scala/csw/framework/internal/pubsub/PubSubBehaviorFactory.scala
+++ b/csw-framework/src/main/scala/csw/framework/internal/pubsub/PubSubBehaviorFactory.scala
@@ -10,6 +10,6 @@ import csw.services.logging.scaladsl.LoggerFactory
  * Factory for creating [[akka.actor.typed.scaladsl.MutableBehavior]] of a pub sub actor
  */
 private[framework] class PubSubBehaviorFactory() {
-  def make[T: Nameable](actorName: String, loggerFactory: LoggerFactory): Behavior[PubSub[T]] =
-    Behaviors.setup[PubSub[T]](ctx ⇒ new PubSubBehavior(ctx, loggerFactory))
+  def make[T: Nameable, U: Nameable](actorName: String, loggerFactory: LoggerFactory): Behavior[PubSub[T, U]] =
+    Behaviors.setup[PubSub[T, U]](ctx ⇒ new PubSubBehavior(ctx, loggerFactory))
 }

--- a/csw-framework/src/main/scala/csw/framework/internal/supervisor/SupervisorBehavior.scala
+++ b/csw-framework/src/main/scala/csw/framework/internal/supervisor/SupervisorBehavior.scala
@@ -30,7 +30,7 @@ import csw.messages.framework._
 import csw.messages.location.ComponentId
 import csw.messages.location.Connection.AkkaConnection
 import csw.messages.params.models.Prefix
-import csw.messages.params.states.CurrentState
+import csw.messages.params.states.{CurrentState, StateName}
 import csw.services.command.CommandResponseManager
 import csw.services.command.internal.CommandResponseManagerFactory
 import csw.services.event.api.scaladsl.EventService
@@ -96,8 +96,8 @@ private[framework] final class SupervisorBehavior(
 
   private val commandResponseManager: CommandResponseManager                      = makeCommandResponseManager()
   private val pubSubBehaviorFactory: PubSubBehaviorFactory                        = new PubSubBehaviorFactory
-  private[framework] val pubSubComponentActor: ActorRef[PubSub[CurrentState]]     = makePubSubComponent()
-  private[framework] val pubSubLifecycle: ActorRef[PubSub[LifecycleStateChanged]] = makePubSubLifecycle()
+  private[framework] val pubSubComponentActor: ActorRef[PubSub[CurrentState, StateName]]     = makePubSubComponent()
+  private[framework] val pubSubLifecycle: ActorRef[PubSub[LifecycleStateChanged, LifecycleStateChanged]] = makePubSubLifecycle()
 
   private var runningComponent: Option[ActorRef[RunningMessage]]  = None
   private var lockManager: LockManager                            = new LockManager(None, loggerFactory)
@@ -332,12 +332,12 @@ private[framework] final class SupervisorBehavior(
 
   private def coordinatedShutdown(reason: Reason): Future[Done] = CoordinatedShutdown(ctx.system.toUntyped).run(reason)
 
-  private def makePubSubComponent(): ActorRef[PubSub[CurrentState]] =
-    ctx.spawn(pubSubBehaviorFactory.make[CurrentState](PubSubComponentActor, loggerFactory),
+  private def makePubSubComponent(): ActorRef[PubSub[CurrentState, StateName]] =
+    ctx.spawn(pubSubBehaviorFactory.make[CurrentState, StateName](PubSubComponentActor, loggerFactory),
               SupervisorBehavior.PubSubComponentActor)
 
-  private def makePubSubLifecycle(): ActorRef[PubSub[LifecycleStateChanged]] =
-    ctx.spawn(pubSubBehaviorFactory.make[LifecycleStateChanged](PubSubComponentActor, loggerFactory),
+  private def makePubSubLifecycle(): ActorRef[PubSub[LifecycleStateChanged, LifecycleStateChanged]] =
+    ctx.spawn(pubSubBehaviorFactory.make[LifecycleStateChanged, LifecycleStateChanged](PubSubComponentActor, loggerFactory),
               SupervisorBehavior.PubSubLifecycleActor)
 
   private def makeCommandResponseManager() = {

--- a/csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java
+++ b/csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java
@@ -434,7 +434,8 @@ public class JCommandIntegrationTest {
         //#subscribeOnlyCurrentState
         // subscribe to the current state of an assembly component and use a callback which forwards each received
         // element to a test probe actor
-        CurrentStateSubscription subscription = hcdCmdService.subscribeOnlyCurrentState(Collections.singleton("testStateSetup"), currentState -> inbox.getRef().tell(currentState));
+        StateName testStateSetup = new StateName("testStateSetup");
+        CurrentStateSubscription subscription = hcdCmdService.subscribeOnlyCurrentState(Collections.singleton(testStateSetup), currentState -> inbox.getRef().tell(currentState));
         //#subscribeOnlyCurrentState
 
         hcdCmdService.submit(setup, timeout);

--- a/csw-framework/src/test/scala/csw/framework/internal/supervisor/SupervisorBehaviorLifecycleTest.scala
+++ b/csw-framework/src/test/scala/csw/framework/internal/supervisor/SupervisorBehaviorLifecycleTest.scala
@@ -22,7 +22,7 @@ import csw.messages.framework.PubSub.{Publish, Subscribe, Unsubscribe}
 import csw.messages.framework.ToComponentLifecycleMessages._
 import csw.messages.framework.{ComponentInfo, LifecycleStateChanged, PubSub, SupervisorLifecycleState}
 import csw.messages.params.models.Id
-import csw.messages.params.states.CurrentState
+import csw.messages.params.states.{CurrentState, StateName}
 import csw.messages.{CommandResponseManagerMessage, ContainerIdleMessage, SupervisorMessage, TopLevelActorMessage}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
@@ -135,7 +135,7 @@ class SupervisorBehaviorLifecycleTest extends FrameworkTestSuite with BeforeAndA
     supervisorBehaviorKit.run(GetSupervisorLifecycleState(supervisorLifecycleStateProbe.ref))
     supervisorLifecycleStateProbe.expectMessage(SupervisorLifecycleState.Running)
 
-    val childPubSubLifecycleInbox: TestInbox[PubSub[LifecycleStateChanged]] =
+    val childPubSubLifecycleInbox: TestInbox[PubSub[LifecycleStateChanged, LifecycleStateChanged]] =
       supervisorBehaviorKit.childInbox(SupervisorBehavior.PubSubLifecycleActor)
 
     childPubSubLifecycleInbox.receiveMessage() shouldBe Publish(
@@ -155,7 +155,7 @@ class SupervisorBehaviorLifecycleTest extends FrameworkTestSuite with BeforeAndA
     supervisorBehaviorKit.run(GetSupervisorLifecycleState(supervisorLifecycleStateProbe.ref))
     supervisorLifecycleStateProbe.expectMessage(SupervisorLifecycleState.Running)
 
-    val childPubSubLifecycleInbox: TestInbox[PubSub[LifecycleStateChanged]] =
+    val childPubSubLifecycleInbox: TestInbox[PubSub[LifecycleStateChanged, LifecycleStateChanged]] =
       supervisorBehaviorKit.childInbox(SupervisorBehavior.PubSubLifecycleActor)
 
     childPubSubLifecycleInbox.receiveMessage() shouldBe Publish(
@@ -180,20 +180,20 @@ class SupervisorBehaviorLifecycleTest extends FrameworkTestSuite with BeforeAndA
     supervisorBehaviorKit.run(GetSupervisorLifecycleState(supervisorLifecycleStateProbe.ref))
     supervisorLifecycleStateProbe.expectMessage(previousSupervisorLifecycleState)
 
-    val childPubSubLifecycleInbox: TestInbox[PubSub[LifecycleStateChanged]] =
+    val childPubSubLifecycleInbox: TestInbox[PubSub[LifecycleStateChanged, LifecycleStateChanged]] =
       supervisorBehaviorKit.childInbox(SupervisorBehavior.PubSubLifecycleActor)
 
     val subscribeMessage = childPubSubLifecycleInbox.receiveMessage()
-    subscribeMessage shouldBe Subscribe[LifecycleStateChanged](subscriberProbe.ref)
+    subscribeMessage shouldBe Subscribe[LifecycleStateChanged, LifecycleStateChanged](subscriberProbe.ref)
 
     // Unsubscribe
-    supervisorBehaviorKit.run(LifecycleStateSubscription(Unsubscribe[LifecycleStateChanged](subscriberProbe.ref)))
+    supervisorBehaviorKit.run(LifecycleStateSubscription(Unsubscribe[LifecycleStateChanged, LifecycleStateChanged](subscriberProbe.ref)))
 
     supervisorBehaviorKit.run(GetSupervisorLifecycleState(supervisorLifecycleStateProbe.ref))
     supervisorLifecycleStateProbe.expectMessage(previousSupervisorLifecycleState)
 
     val unsubscribeMessage = childPubSubLifecycleInbox.receiveMessage()
-    unsubscribeMessage shouldBe Unsubscribe[LifecycleStateChanged](subscriberProbe.ref)
+    unsubscribeMessage shouldBe Unsubscribe[LifecycleStateChanged, LifecycleStateChanged](subscriberProbe.ref)
   }
 
   test("supervisor should handle ComponentStateSubscription message by coordinating with pub sub actor") {
@@ -207,23 +207,23 @@ class SupervisorBehaviorLifecycleTest extends FrameworkTestSuite with BeforeAndA
     val previousSupervisorLifecycleState = supervisorLifecycleStateProbe.expectMessageType[SupervisorLifecycleState]
 
     // Subscribe
-    supervisorBehaviorKit.run(ComponentStateSubscription(Subscribe[CurrentState](subscriberProbe.ref)))
+    supervisorBehaviorKit.run(ComponentStateSubscription(Subscribe[CurrentState, StateName](subscriberProbe.ref)))
     supervisorBehaviorKit.run(GetSupervisorLifecycleState(supervisorLifecycleStateProbe.ref))
     supervisorLifecycleStateProbe.expectMessage(previousSupervisorLifecycleState)
 
-    val childPubSubComponentStateInbox: TestInbox[PubSub[CurrentState]] =
+    val childPubSubComponentStateInbox: TestInbox[PubSub[CurrentState, StateName]] =
       supervisorBehaviorKit.childInbox(SupervisorBehavior.PubSubComponentActor)
 
     val subscribeMessage = childPubSubComponentStateInbox.receiveMessage()
-    subscribeMessage shouldBe Subscribe[CurrentState](subscriberProbe.ref)
+    subscribeMessage shouldBe Subscribe[CurrentState, StateName](subscriberProbe.ref)
 
     // Unsubscribe
-    supervisorBehaviorKit.run(ComponentStateSubscription(Unsubscribe[CurrentState](subscriberProbe.ref)))
+    supervisorBehaviorKit.run(ComponentStateSubscription(Unsubscribe[CurrentState, StateName](subscriberProbe.ref)))
     supervisorBehaviorKit.run(GetSupervisorLifecycleState(supervisorLifecycleStateProbe.ref))
     supervisorLifecycleStateProbe.expectMessage(previousSupervisorLifecycleState)
 
     val unsubscribeMessage = childPubSubComponentStateInbox.receiveMessage()
-    unsubscribeMessage shouldBe Unsubscribe[CurrentState](subscriberProbe.ref)
+    unsubscribeMessage shouldBe Unsubscribe[CurrentState, StateName](subscriberProbe.ref)
   }
 
   // *************** End of testing onCommonMessages ***************

--- a/csw-messages/src/main/scala/csw/messages/commands/Nameable.scala
+++ b/csw-messages/src/main/scala/csw/messages/commands/Nameable.scala
@@ -1,5 +1,46 @@
 package csw.messages.commands
 
+import csw.messages.framework.LifecycleStateChanged
+import csw.messages.params.states.{CurrentState, StateName}
+
+/**
+  * The Nameable typeclass provides a name function that returns a String that can be used for comparing
+  * within the [[csw.framework.internal.pubsub]] actor to allow the subscribeOnly by Nameable
+  *
+  * @tparam T - Type supporting the Nameable typeclass
+  */
 trait Nameable[T] {
   def name(state: T): String
+}
+
+object Nameable {
+
+  /**
+    * This allows use of Nameable[A}
+    */
+  def apply[A](implicit nm: Nameable[A]):Nameable[A] = nm
+
+  def name[A: Nameable](thing: A): String = Nameable[A].name(thing)
+
+  implicit class NameableOps[A](val thing: A) extends AnyVal {
+    def name(implicit nm: Nameable[A]): String = nm.name(thing)
+  }
+
+  /**
+    * The following three implicit objects are required to support the Nameable typeclass used
+    * by [[csw.framework.internal.pubsub]] to allow subscribeOnly
+    * These evidence classes are here so Nameable is easier to understand and it isn't scattered across the source tree
+    */
+  implicit object NameableLifecycleStateChanged extends Nameable[LifecycleStateChanged] {
+    override def name(state: LifecycleStateChanged): String = state.state.toString
+  }
+
+  implicit object NameableCurrentState extends Nameable[CurrentState] {
+    override def name(state: CurrentState): String = state.stateName.name
+  }
+
+  implicit object StateNameIsNameable extends Nameable[StateName] {
+    def name(sn: StateName): String = sn.name
+  }
+
 }

--- a/csw-messages/src/main/scala/csw/messages/framework/LifecycleStateChanged.scala
+++ b/csw-messages/src/main/scala/csw/messages/framework/LifecycleStateChanged.scala
@@ -1,7 +1,6 @@
 package csw.messages.framework
 
 import akka.actor.typed.ActorRef
-import csw.messages.commands.Nameable
 import csw.messages.{ComponentMessage, TMTSerializable}
 
 /**
@@ -12,9 +11,3 @@ import csw.messages.{ComponentMessage, TMTSerializable}
  */
 case class LifecycleStateChanged private[messages] (publisher: ActorRef[ComponentMessage], state: SupervisorLifecycleState)
     extends TMTSerializable
-
-object LifecycleStateChanged {
-  implicit object NameableLifecycleStateChanged extends Nameable[LifecycleStateChanged] {
-    override def name(state: LifecycleStateChanged): String = state.state.toString
-  }
-}

--- a/csw-messages/src/main/scala/csw/messages/framework/PubSub.scala
+++ b/csw-messages/src/main/scala/csw/messages/framework/PubSub.scala
@@ -8,7 +8,7 @@ import csw.messages.TMTSerializable
  *
  * @tparam T represents the type of data that is published or subscribed
  */
-sealed trait PubSub[T] extends TMTSerializable
+sealed trait PubSub[T, U] extends TMTSerializable
 object PubSub {
 
   /**
@@ -16,7 +16,7 @@ object PubSub {
    *
    * @tparam T represents the type of data that is subscribed
    */
-  sealed trait SubscriberMessage[T] extends PubSub[T]
+  sealed trait SubscriberMessage[T, U] extends PubSub[T, U]
 
   /**
    * Represents a subscribe action
@@ -24,8 +24,8 @@ object PubSub {
    * @param ref the reference of subscriber used to notify to when some data is published
    * @tparam T represents the type of data that is subscribed
    */
-  case class Subscribe[T](ref: ActorRef[T])                         extends SubscriberMessage[T]
-  case class SubscribeOnly[T](ref: ActorRef[T], names: Set[String]) extends SubscriberMessage[T]
+  case class Subscribe[T, U](ref: ActorRef[T])                         extends SubscriberMessage[T, U]
+  case class SubscribeOnly[T, U](ref: ActorRef[T], names: Set[U]) extends SubscriberMessage[T, U]
 
   /**
    * Represents a unsubscribe action
@@ -33,14 +33,14 @@ object PubSub {
    * @param ref the reference of subscriber that no longer wishes to receive notification for published data
    * @tparam T represents the type of data that is subscribed
    */
-  case class Unsubscribe[T](ref: ActorRef[T]) extends SubscriberMessage[T]
+  case class Unsubscribe[T, U](ref: ActorRef[T]) extends SubscriberMessage[T, U]
 
   /**
    * Represents the messages about publishing data e.g Publish
    *
    * @tparam T represents the type of data that is published
    */
-  sealed trait PublisherMessage[T] extends PubSub[T]
+  sealed trait PublisherMessage[T, U] extends PubSub[T, U]
 
   /**
    * Represents a publish action
@@ -48,5 +48,5 @@ object PubSub {
    * @param data of type T that gets published
    * @tparam T represents the type of data that is published
    */
-  case class Publish[T](data: T) extends PublisherMessage[T]
+  case class Publish[T, U](data: T) extends PublisherMessage[T, U]
 }

--- a/csw-messages/src/main/scala/csw/messages/messages.scala
+++ b/csw-messages/src/main/scala/csw/messages/messages.scala
@@ -6,7 +6,7 @@ import csw.messages.framework.PubSub.SubscriberMessage
 import csw.messages.framework._
 import csw.messages.location.TrackingEvent
 import csw.messages.params.models.{Id, Prefix}
-import csw.messages.params.states.CurrentState
+import csw.messages.params.states.{CurrentState, StateName}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -173,7 +173,7 @@ object ComponentCommonMessage {
    *
    * @param subscriberMessage tells the component to subscribe to or unsubscribe from LifecycleStateChanged notifications
    */
-  case class LifecycleStateSubscription(subscriberMessage: SubscriberMessage[LifecycleStateChanged])
+  case class LifecycleStateSubscription(subscriberMessage: SubscriberMessage[LifecycleStateChanged, LifecycleStateChanged])
       extends ComponentCommonMessage
 
   /**
@@ -181,7 +181,7 @@ object ComponentCommonMessage {
    *
    * @param subscriberMessage tells the component to subscribe to or unsubscribe from CurrentState notifications
    */
-  case class ComponentStateSubscription(subscriberMessage: SubscriberMessage[CurrentState]) extends ComponentCommonMessage
+  case class ComponentStateSubscription(subscriberMessage: SubscriberMessage[CurrentState, StateName]) extends ComponentCommonMessage
 
   /**
    * Represents a message to get current lifecycle state of a component

--- a/csw-messages/src/main/scala/csw/messages/params/states/StateVariable.scala
+++ b/csw-messages/src/main/scala/csw/messages/params/states/StateVariable.scala
@@ -1,6 +1,6 @@
 package csw.messages.params.states
 
-import csw.messages.commands.{Nameable, Setup}
+import csw.messages.commands.Setup
 import csw.messages.params.generics.{Parameter, ParameterSetKeyData, ParameterSetType}
 import csw.messages.params.models.Prefix
 import csw.messages.params.states.StateVariable.StateVariable
@@ -166,7 +166,4 @@ object CurrentState {
       paramSet: Set[Parameter[_]] = Set.empty[Parameter[_]]
   ): CurrentState = new CurrentState(prefix, stateName).madd(paramSet)
 
-  implicit object NameableCurrentState extends Nameable[CurrentState] {
-    override def name(state: CurrentState): String = state.stateName.name
-  }
 }


### PR DESCRIPTION
…in a generic way through the Nameable typeclass for both parameters T and U.  All the Nameable functionality is in Nameable. I couldn't see

different way to do this due to lack of a relationship between
CurrentState and StateName, that must be compared in the publish
method.