### PR TITLE
#DEOPSCSW-000: Shubham | Poorva: Remove realm and auth-server-url fro…

### DIFF
--- a/csw-auth/native-client-adapter/src/main/resources/application.conf
+++ b/csw-auth/native-client-adapter/src/main/resources/application.conf
@@ -1,6 +1,4 @@
 auth-config {
-  realm = master
-  auth-server-url = "http://localhost:8080/auth"
   ssl-required = external
   resource = admin-cli
   public-client = true

--- a/csw-config-api/src/main/scala/csw/config/api/internal/JsonSupport.scala
+++ b/csw-config-api/src/main/scala/csw/config/api/internal/JsonSupport.scala
@@ -30,8 +30,19 @@ private[config] trait JsonSupport extends PlayJsonSupport {
     }
   }
 
-  implicit val configIdFormat: Format[ConfigId]              = Json.format[ConfigId]
-  implicit val configFileInfoFormat: OFormat[ConfigFileInfo] = Json.format[ConfigFileInfo]
+  implicit val configIdFormat: Format[ConfigId] = Json.format[ConfigId]
+
+  implicit val configFileInfoFormat: OFormat[ConfigFileInfo] = {
+    implicit val configIdFormat: Format[ConfigId] = new Format[ConfigId] {
+      override def writes(o: ConfigId): JsValue = JsString(o.id)
+      override def reads(json: JsValue): JsResult[ConfigId] = json match {
+        case JsString(x) ⇒ JsSuccess(ConfigId(x))
+        case _           ⇒ JsError(s"can not parse $json into configId")
+      }
+    }
+    Json.format[ConfigFileInfo]
+  }
+
   implicit val configFileHistoryFormat: OFormat[ConfigFileRevision] = {
     implicit val configIdFormat: Format[ConfigId] = new Format[ConfigId] {
       override def writes(o: ConfigId): JsValue = JsString(o.id)


### PR DESCRIPTION
…m native adapter conf. Add custom json formatter for ConfigId.

Conf file params are already specified in auth-core application.conf.
Custom Json formatter to remove nested json for configId

Co-authored-by: Shubham Jaybhaye <shubhamj7997@gmail.com>