### PR TITLE
#CSW-20: Kim : Added requested hcdBusyIssue

### DIFF
--- a/csw-contract/src/main/scala/csw/contract/data/command/CommandContract.scala
+++ b/csw-contract/src/main/scala/csw/contract/data/command/CommandContract.scala
@@ -42,6 +42,7 @@ object CommandContract extends CommandData with CommandServiceCodecs {
       requiredSequencerUnavailableIssue,
       requiredServiceUnavailableIssue,
       requiredHCDUnavailableIssue,
+      hcdBusyIssue,
       unresolvedLocationsIssue,
       unsupportedCommandInStateIssue,
       unsupportedCommandIssue,

--- a/csw-contract/src/main/scala/csw/contract/data/command/CommandData.scala
+++ b/csw-contract/src/main/scala/csw/contract/data/command/CommandData.scala
@@ -98,6 +98,7 @@ trait CommandData {
   val requiredSequencerUnavailableIssue: CommandIssue = RequiredSequencerUnavailableIssue(reason)
   val requiredServiceUnavailableIssue: CommandIssue   = RequiredServiceUnavailableIssue(reason)
   val requiredHCDUnavailableIssue: CommandIssue       = RequiredHCDUnavailableIssue(reason)
+  val hcdBusyIssue: CommandIssue                      = HCDBusyIssue(reason)
   val unresolvedLocationsIssue: CommandIssue          = UnresolvedLocationsIssue(reason)
   val unsupportedCommandInStateIssue: CommandIssue    = UnsupportedCommandInStateIssue(reason)
   val unsupportedCommandIssue: CommandIssue           = UnsupportedCommandIssue(reason)

--- a/csw-params/shared/src/main/scala/csw/params/commands/CommandIssue.scala
+++ b/csw-params/shared/src/main/scala/csw/params/commands/CommandIssue.scala
@@ -110,11 +110,18 @@ object CommandIssue {
   final case class RequiredServiceUnavailableIssue(reason: String) extends CommandIssue
 
   /**
-   *  sA required HCD is not available
+   *  A required HCD is not available
    *
    * @param reason describing the cause of this issue
    */
   final case class RequiredHCDUnavailableIssue(reason: String) extends CommandIssue
+
+  /**
+   *  A required HCD is busy and cannot be used
+   *
+   * @param reason describing the cause of this issue
+   */
+  final case class HCDBusyIssue(reason: String) extends CommandIssue
 
   /**
    * A required Assembly is not available

--- a/csw-params/shared/src/test/scala/csw/params/core/formats/CborTest.scala
+++ b/csw-params/shared/src/test/scala/csw/params/core/formats/CborTest.scala
@@ -106,6 +106,7 @@ class CborTest extends AnyFunSuite with Matchers {
       UnsupportedCommandInStateIssue(""),
       RequiredServiceUnavailableIssue(""),
       RequiredHCDUnavailableIssue(""),
+      HCDBusyIssue(""),
       RequiredAssemblyUnavailableIssue(""),
       RequiredSequencerUnavailableIssue(""),
       OtherIssue("")


### PR DESCRIPTION
**What**:
This pull request satisfies <CSW-20> that requested we add a new CommandIssue to indicate an HCD is busy called HCDBusyIssue.
**Why**
This issue is pretty old and it's pretty easy so I thought I would try to add it in for 2.0.
**Description**
Adding the new CommandIssue involved adding an issue to CommandIssue object. A CommandIssue appears in other places related to serialization and scripting (CommandData?). The CborTest passes after this change.
**Issues**
This change will possibly require the serialization contract be reviewed for changes.  The Python API may need to be reviewed.