### PR TITLE
#000: Poorva: Remove add artifact from multiJvm plugin

### DIFF
--- a/project/AutoMultiJvm.scala
+++ b/project/AutoMultiJvm.scala
@@ -27,7 +27,7 @@ object AutoMultiJvm extends AutoPlugin {
           val oldStrategy = (assemblyMergeStrategy in assembly in MultiJvm).value
           oldStrategy(x)
       }
-    ) ++ addArtifact(multiJvmArtifact, packageBin in MultiJvm)
+    )
 
   override def projectConfigurations: Seq[Configuration] = List(MultiJvm)
 


### PR DESCRIPTION
This was added for acceptance build. But acceptance tests build is removed now so this step is not needed