### PR TITLE
#CSW-115: Himanshu | Make interface name cli param in csw services co…

### DIFF
--- a/csw-services/src/main/scala/csw/services/cli/Command.scala
+++ b/csw-services/src/main/scala/csw/services/cli/Command.scala
@@ -27,7 +27,7 @@ object Command {
       auth: Boolean = false,
       @HelpMessage("name of the inside interface")
       @Short("i")
-      insideInterfaceName: Option[String],
+      interfaceName: Option[String],
       @HelpMessage("name of the outside interface")
       @Short("o")
       outsideInterfaceName: Option[String]

--- a/csw-services/src/main/scala/csw/services/internal/Environment.scala
+++ b/csw-services/src/main/scala/csw/services/internal/Environment.scala
@@ -5,7 +5,7 @@ class Environment(settings: Settings) {
     import settings._
     System.setProperty("CLUSTER_SEEDS", s"$hostName:$clusterPort")
     System.setProperty("csw-location-server.http-port", locationHttpPort)
-    System.setProperty("INTERFACE_NAME", insideInterfaceName)
+    System.setProperty("INTERFACE_NAME", interfaceName)
     System.setProperty("AAS_INTERFACE_NAME", outsideInterfaceName)
     System.setProperty("TMT_LOG_HOME", logHome)
   }

--- a/csw-services/src/main/scala/csw/services/internal/Settings.scala
+++ b/csw-services/src/main/scala/csw/services/internal/Settings.scala
@@ -13,22 +13,22 @@ case class Settings(
     alarmPort: String,
     sentinelPort: String,
     logHome: String,
-    insideInterfaceName: String,
+    interfaceName: String,
     outsideInterfaceName: String,
     keycloakPort: String,
     configAdminUsername: String,
     configAdminPassword: String
 ) {
-  val hostName: String = Networks.interface(Some(insideInterfaceName)).hostname
+  val hostName: String = Networks.interface(Some(interfaceName)).hostname
 }
 
 object Settings {
-  def apply(insideInterface: Option[String] = None, outsideInterface: Option[String] = None): Settings = {
+  def apply(interface: Option[String] = None, outsideInterface: Option[String] = None): Settings = {
     val config = ConfigFactory.load().getConfig("csw")
 
     // automatically determine correct interface if INTERFACE_NAME env variable not set or -i command line option not provided
-    val insideInterfaceName  = insideInterface.getOrElse((sys.env ++ sys.props).getOrElse("INTERFACE_NAME", ""))
-    val outsideInterfaceName = outsideInterface.getOrElse(insideInterfaceName)
+    val interfaceName        = interface.getOrElse((sys.env ++ sys.props).getOrElse("INTERFACE_NAME", ""))
+    val outsideInterfaceName = outsideInterface.getOrElse(interfaceName)
 
     new Settings(
       config.getString("clusterPort"),
@@ -40,7 +40,7 @@ object Settings {
       config.getString("alarmPort"),
       config.getString("sentinelPort"),
       config.getString("logHome"),
-      insideInterfaceName,
+      interfaceName,
       outsideInterfaceName,
       config.getString("keycloakPort"),
       config.getString("configAdminUsername"),

--- a/csw-services/src/main/scala/csw/services/internal/Wiring.scala
+++ b/csw-services/src/main/scala/csw/services/internal/Wiring.scala
@@ -21,7 +21,7 @@ class Wiring(startCmd: Start) {
   lazy implicit val actorSystem: ActorSystem[SpawnProtocol.Command] = ActorSystemFactory.remote(SpawnProtocol())
   lazy implicit val ec: ExecutionContext                            = actorSystem.executionContext
 
-  lazy val settings: Settings                     = Settings(startCmd.insideInterfaceName, startCmd.outsideInterfaceName)
+  lazy val settings: Settings                     = Settings(startCmd.interfaceName, startCmd.outsideInterfaceName)
   lazy val locationServiceClient: LocationService = HttpLocationServiceFactory.makeLocalClient
 
   lazy val environment   = new Environment(settings)

--- a/docs/src/main/apps/cswservices.md
+++ b/docs/src/main/apps/cswservices.md
@@ -54,7 +54,7 @@ csw-services start
     // This starts all the services and sets the inside interface name to en0.
     csw-services start -i en0
     ```  
-- --outside-interface-name | -o if provided, helps you set the outside interface name.
+- --outside-interface-name | -o if provided, helps you set the outside interface name, if not provided will fallback to --interface-name
 
     ```bash
     // This starts all the services and sets the outside interface name to en0.

--- a/docs/src/main/apps/cswservices.md
+++ b/docs/src/main/apps/cswservices.md
@@ -48,7 +48,7 @@ csw-services start
 
 `start` command support following additional options:
 
-- --inside-interface-name | -i if provided, helps you set the inside interface name.
+- --interface-name | -i if provided, helps you set the inside interface name.
 
     ```bash
     // This starts all the services and sets the inside interface name to en0.


### PR DESCRIPTION
This is minor change and miss from our side. 

This
csw-services start –**inside**-interface-name | -i en0  ....................(maps to INTERFACE_NAME)
csw-services start –outside-interface-name | -o en1 ........................(maps to AAS_INTERFACE_NAME)

changed to
csw-services start –interface-name | -i en0  ..................................  (maps to INTERFACE_NAME)
csw-services start –outside-interface-name | -o en1   .................... (maps to AAS_INTERFACE_NAME)