### PR TITLE
Improve exception message for ParameterSet apply/parameter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -492,7 +492,7 @@ lazy val `csw-time-core` = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(`csw-time-clock`)
   .jvmConfigure(_.enablePlugins(GenJavadocPlugin))
   .jsSettings(jsTestArg)
-  .jvmSettings(libraryDependencies += Libs.`junit-4-12` % Test)
+  .jvmSettings(libraryDependencies += Libs.`junit-4-13` % Test)
   .settings(
     libraryDependencies += Libs.`scalatest`.value % Test,
     fork := false

--- a/csw-params/jvm/src/test/java/csw/params/commands/JCommandsTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/commands/JCommandsTest.java
@@ -6,17 +6,14 @@ import csw.params.core.generics.ParameterSetType;
 import csw.params.core.models.ObsId;
 import csw.params.javadsl.JKeyType;
 import csw.params.javadsl.JUnits;
+import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import org.junit.Assert;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
-import csw.prefix.javadsl.JSubsystem;
 
 // DEOPSCSW-183: Configure attributes and values
 // DEOPSCSW-185: Easy to Use Syntax/Api
@@ -62,6 +59,8 @@ public class JCommandsTest extends JUnitSuite {
 
         // parameter
         Assert.assertEquals(epochStringParam, command.parameter(epochStringKey));
+        Exception ex = Assert.assertThrows(NoSuchElementException.class, () -> command.parameter(notUsedKey));
+        Assert.assertEquals(ex.getMessage(), "Parameter set does not contain key: "+notUsedKey.keyName());
 
         // jMissingKeys
         Set<String> expectedMissingKeys = Set.of(notUsedKey.keyName());
@@ -169,7 +168,7 @@ public class JCommandsTest extends JUnitSuite {
 
     /*
     @Test
-    public void shoulRdAbleToCloneAnExistingCommand__DEOPSCSW_183_DEOPSCSW_185_DEOPSCSW_320() {
+    public void shouldAbleToCloneAnExistingCommand__DEOPSCSW_183_DEOPSCSW_185_DEOPSCSW_320() {
         Setup setup = new Setup(prefix, commandName, Optional.of(obsId)).add(encoderParam).add(epochStringParam);
         Setup setup2 = setup.cloneCommand();
         Assert.assertNotEquals(setup.runId(), setup2.runId());

--- a/csw-params/jvm/src/test/java/csw/params/events/JEventsTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/events/JEventsTest.java
@@ -68,6 +68,8 @@ public class JEventsTest extends JUnitSuite {
 
         // parameter
         Assert.assertEquals(epochStringParam, event.parameter(epochStringKey));
+        Exception ex = Assert.assertThrows(NoSuchElementException.class, () -> event.parameter(notUsedKey));
+        Assert.assertEquals(ex.getMessage(), "Parameter set does not contain key: "+notUsedKey.keyName());
 
         // jMissingKeys
         var expectedMissingKeys = Set.of(notUsedKey.keyName());

--- a/csw-params/shared/src/main/scala/csw/params/core/generics/ParameterSetType.scala
+++ b/csw-params/shared/src/main/scala/csw/params/core/generics/ParameterSetType.scala
@@ -1,9 +1,9 @@
 package csw.params.core.generics
 
 import java.util
-
 import csw.params.extensions.OptionConverters.RichOption
 
+import java.util.NoSuchElementException
 import scala.annotation.varargs
 import scala.jdk.CollectionConverters._
 
@@ -135,7 +135,7 @@ abstract class ParameterSetType[T <: ParameterSetType[T]] { self: T =>
    * @tparam S the Scala value type
    * @return the parameter associated with the Key or a NoSuchElementException if the key does not exist
    */
-  final def apply[S](key: Key[S]): Parameter[S] = get(key).get
+  final def apply[S](key: Key[S]): Parameter[S] = getWithExceptionMessage(key)
 
   /**
    * Returns the actual parameter associated with a key
@@ -144,7 +144,10 @@ abstract class ParameterSetType[T <: ParameterSetType[T]] { self: T =>
    * @tparam S the Scala value type
    * @return the parameter associated with the key or a NoSuchElementException if the key does not exist
    */
-  final def parameter[S](key: Key[S]): Parameter[S] = get(key).get
+  final def parameter[S](key: Key[S]): Parameter[S] = getWithExceptionMessage(key)
+
+  private def getWithExceptionMessage[S](key: Key[S]): Parameter[S] =
+    get(key).getOrElse(throw new NoSuchElementException(s"Parameter set does not contain key: ${key.keyName}"))
 
   /**
    * Returns true if the key exists in the parameter set

--- a/csw-params/shared/src/test/scala/csw/params/commands/CommandsTest.scala
+++ b/csw-params/shared/src/test/scala/csw/params/commands/CommandsTest.scala
@@ -71,6 +71,11 @@ class CommandsTest extends AnyFunSpec {
       assert(v1.values === Array(22))
       assert(v2.values === Array("C"))
       assert(sc1(k2)(0) == "C")
+      val ex = intercept[NoSuchElementException](sc1(k3))
+      assert(ex.getMessage == s"Parameter set does not contain key: ${k3.keyName}")
+      val ex2 = intercept[NoSuchElementException](sc1.parameter(k3))
+      assert(ex2.getMessage == s"Parameter set does not contain key: ${k3.keyName}")
+
     }
 
     // DEOPSCSW-190: Implement Unit Support
@@ -166,6 +171,7 @@ class CommandsTest extends AnyFunSpec {
 
     val k1 = KeyType.IntKey.make("repeat")
     val k2 = KeyType.IntKey.make("expTime")
+    val k3 = KeyType.IntKey.make("notUsed")
     it("Should allow adding keys | DEOPSCSW-183, DEOPSCSW-185, DEOPSCSW-196, DEOPSCSW-320") {
       val i1  = k1.set(22)
       val i2  = k2.set(44)
@@ -199,6 +205,10 @@ class CommandsTest extends AnyFunSpec {
       assert(oc1.get(k2).isDefined)
       assert(v1.values === Array(22))
       assert(v2.head == 44)
+      val ex = intercept[NoSuchElementException](oc1(k3))
+      assert(ex.getMessage == s"Parameter set does not contain key: ${k3.keyName}")
+      val ex2 = intercept[NoSuchElementException](oc1.parameter(k3))
+      assert(ex2.getMessage == s"Parameter set does not contain key: ${k3.keyName}")
     }
 
     it("should update for the same key with set | DEOPSCSW-183, DEOPSCSW-185, DEOPSCSW-196, DEOPSCSW-320") {
@@ -251,6 +261,7 @@ class CommandsTest extends AnyFunSpec {
 
     val k1 = KeyType.IntKey.make("repeat")
     val k2 = KeyType.IntKey.make("expTime")
+    val k3 = KeyType.IntKey.make("unused")
     it("Should allow adding keys | DEOPSCSW-183, DEOPSCSW-185, DEOPSCSW-196, DEOPSCSW-320") {
       val i1  = k1.set(22)
       val i2  = k2.set(44)
@@ -284,6 +295,11 @@ class CommandsTest extends AnyFunSpec {
       assert(wc1.get(k2).isDefined)
       assert(v1.values === Array(22))
       assert(v2.head == 44)
+      val ex = intercept[NoSuchElementException](wc1(k3))
+      assert(ex.getMessage == s"Parameter set does not contain key: ${k3.keyName}")
+      val ex2 = intercept[NoSuchElementException](wc1.parameter(k3))
+      assert(ex2.getMessage == s"Parameter set does not contain key: ${k3.keyName}")
+
     }
 
     it("should update for the same key with set | DEOPSCSW-183, DEOPSCSW-185, DEOPSCSW-196, DEOPSCSW-320") {

--- a/csw-params/shared/src/test/scala/csw/params/events/EventsTest.scala
+++ b/csw-params/shared/src/test/scala/csw/params/events/EventsTest.scala
@@ -40,7 +40,13 @@ class EventsTest extends AnyFunSpec with Matchers {
       assert(sc1.exists(k2))
       assert(sc1(k1).head == 22)
       assert(sc1(k2).head == 44)
+      assert(sc1.parameter(k1).head == 22)
+      assert(sc1.parameter(k2).head == 44)
       assert(sc1.missingKeys(k1, k2, k3) == Set(k3.keyName))
+      val ex = intercept[NoSuchElementException](sc1(k4))
+      ex.getMessage shouldBe s"Parameter set does not contain key: ${k4.keyName}"
+      val ex2 = intercept[NoSuchElementException](sc1.parameter(k3))
+      ex2.getMessage shouldBe s"Parameter set does not contain key: ${k3.keyName}"
     }
 
     it(
@@ -144,7 +150,13 @@ class EventsTest extends AnyFunSpec with Matchers {
       assert(sc1.exists(k2))
       assert(sc1(k1).head == 22)
       assert(sc1(k2).head == 44)
+      assert(sc1.parameter(k1).head == 22)
+      assert(sc1.parameter(k2).head == 44)
       assert(sc1.missingKeys(k1, k2, k3) == Set(k3.keyName))
+      val ex = intercept[NoSuchElementException](sc1(k4))
+      ex.getMessage shouldBe s"Parameter set does not contain key: ${k4.keyName}"
+      val ex2 = intercept[NoSuchElementException](sc1.parameter(k3))
+      ex2.getMessage shouldBe s"Parameter set does not contain key: ${k3.keyName}"
     }
 
     it(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -183,7 +183,7 @@ object Dependencies {
   val ParamsJvm = Def.setting(
     Seq(
       Libs.`play-json`,
-      Libs.`junit-4-12` % Test
+      Libs.`junit-4-13` % Test
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
       AkkaHttp.`akka-http-spray-json`, // akka-cluster-management uses lower version, to avoid conflict, this needs to be overridden
       MSocket.`msocket-http`,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-12`               % Test,
+      Libs.`junit-4-13`               % Test,
       Libs.`mockito-scala`            % Test,
       Akka.`akka-actor-testkit-typed` % Test,
       Libs.`jboss-logging`            % Test,
@@ -54,7 +54,7 @@ object Dependencies {
       Libs.`scala-java8-compat`,
       MSocket.`msocket-http`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test
+      Libs.`junit-4-13`      % Test
     )
   )
 
@@ -121,7 +121,7 @@ object Dependencies {
       Libs.`scala-async`,
       Libs.`scala-java8-compat`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test,
+      Libs.`junit-4-13`      % Test,
       Libs.`mockito-scala`   % Test
     )
   )
@@ -156,7 +156,7 @@ object Dependencies {
       Akka.`akka-actor`,
       Akka.`akka-actor-typed`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test,
+      Libs.`junit-4-13`      % Test,
       Borer.`borer-core`.value,
       Libs.`gson` % Test
     )
@@ -202,7 +202,7 @@ object Dependencies {
       Akka.`akka-actor-testkit-typed` % Test,
       Akka.`akka-stream-testkit`      % Test,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-12`               % Test,
+      Libs.`junit-4-13`               % Test,
       Libs.`mockito-scala`            % Test
     )
   )
@@ -224,7 +224,7 @@ object Dependencies {
       Akka.`akka-actor-testkit-typed` % Test,
       Akka.`akka-stream-testkit`      % Test,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-12`               % Test,
+      Libs.`junit-4-13`               % Test,
       Libs.`mockito-scala`            % Test
     )
   )
@@ -263,7 +263,7 @@ object Dependencies {
       Akka.`akka-multi-node-testkit`  % Test,
       Akka.`akka-actor-testkit-typed` % Test,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-12`               % Test,
+      Libs.`junit-4-13`               % Test,
       Libs.`mockito-scala`            % Test,
       Libs.`embedded-redis`           % Test,
       Libs.`embedded-kafka`           % Test,
@@ -319,7 +319,7 @@ object Dependencies {
       Akka.`akka-stream`,
       Akka.`akka-stream-typed`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test,
+      Libs.`junit-4-13`      % Test,
       Libs.`mockito-scala`   % Test
     )
   )
@@ -354,7 +354,7 @@ object Dependencies {
       //TODO: make this as provided deps
       Libs.`scalatest`.value,
       Libs.`embedded-redis`,
-      Libs.`junit-4-12`,
+      Libs.`junit-4-13`,
       Libs.`mockito-scala`
     )
   )
@@ -363,7 +363,7 @@ object Dependencies {
     Seq(
       Libs.`jna`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test
+      Libs.`junit-4-13`      % Test
     )
   )
 
@@ -388,7 +388,7 @@ object Dependencies {
       Jooq.`jooq-meta`,
       Jooq.`jooq-codegen`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test,
+      Libs.`junit-4-13`      % Test,
       Akka.`akka-actor`      % Test,
       Libs.`otj-pg-embedded` % Test
     )
@@ -485,7 +485,7 @@ object Dependencies {
       AkkaHttp.`akka-http-cors`,
       Akka.`akka-actor-testkit-typed`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test
+      Libs.`junit-4-13`      % Test
     )
   )
 
@@ -503,14 +503,14 @@ object Dependencies {
       Jackson.`jackson-databind`,
       Akka.`akka-actor-testkit-typed`,
       Libs.`scalatest`.value % Test,
-      Libs.`junit-4-12`      % Test
+      Libs.`junit-4-13`      % Test
     )
   )
 
   val Integration = Def.setting(
     Seq(
       Libs.`scalatest`.value,
-      Libs.`junit-4-12`,
+      Libs.`junit-4-13`,
       Libs.`mockito-scala`,
       Akka.`akka-actor`,
       Akka.`akka-actor-typed`,

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -36,6 +36,7 @@ object Libs {
   val `HdrHistogram`      = "org.hdrhistogram"         % "HdrHistogram"      % "2.1.12"
   val `testng`            = "org.testng"               % "testng"            % "7.3.0"
   val `junit-4-12`        = "org.scalatestplus"       %% "junit-4-12"        % "3.2.2.0"
+  val `junit-4-13`        = "org.scalatestplus"       %% "junit-4-13"        % "3.2.5.0"
   val `testng-6-7`        = "org.scalatestplus"       %% "testng-6-7"        % "3.2.2.0"
 
   val `scala-csv`             = "com.github.tototoshi" %% "scala-csv"             % "1.3.6"

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -35,7 +35,6 @@ object Libs {
   val `scala-compiler`    = "org.scala-lang"           % "scala-compiler"    % ScalaVersion
   val `HdrHistogram`      = "org.hdrhistogram"         % "HdrHistogram"      % "2.1.12"
   val `testng`            = "org.testng"               % "testng"            % "7.3.0"
-  val `junit-4-12`        = "org.scalatestplus"       %% "junit-4-12"        % "3.2.2.0"
   val `junit-4-13`        = "org.scalatestplus"       %% "junit-4-13"        % "3.2.5.0"
   val `testng-6-7`        = "org.scalatestplus"       %% "testng-6-7"        % "3.2.2.0"
 


### PR DESCRIPTION
I was working on a test for a sequencer script and found that if I tried to extract a param from a command that didn't exist, I got an `CommandResponse.Error` as expected, but the message was "None.get".  This is not very helpful.  I tracked this down to `ParameterSetType` apply and parameter methods which both do a `get(key).get`, with `get(key)` returning a `None` if the key isn't found in the set.  Doing the second get on the `None` throws a `NoSuchElementException` with that message.  So I changed it to throw a more informative message.  I also updated some tests to ensure this behavior.  Note: I upgraded the JUnit used in Java `csw-params` tests to use 4.13 since it has `assertThrows` method which makes the tests much simpler to write.  