### PR TITLE
#CSW-181 Documentation updates

### DIFF
--- a/csw-framework/src/test/java/csw/framework/javadsl/components/JDetectorComponentHandlers.java
+++ b/csw-framework/src/test/java/csw/framework/javadsl/components/JDetectorComponentHandlers.java
@@ -104,15 +104,11 @@ public class JDetectorComponentHandlers extends JComponentHandlers {
     public void onGoOnline() {
     }
 
-    //#onDiagnostic-mode
     @Override
     public void onDiagnosticMode(UTCTime startTime, String hint) {
     }
-    //#onDiagnostic-mode
 
-    //#onOperations-mode
     @Override
     public void onOperationsMode() {
     }
-    //#onOperations-mode
 }

--- a/csw-framework/src/test/scala/csw/common/components/command/CommandHcdHandlers.scala
+++ b/csw-framework/src/test/scala/csw/common/components/command/CommandHcdHandlers.scala
@@ -24,10 +24,8 @@ class CommandHcdHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: CswCon
     log.info("Initializing HCD Component TLA")
     Thread.sleep(100)
 
-    // #currentStatePublisher
     // Publish the CurrentState using parameter set created using a sample Choice parameter
     currentStatePublisher.publish(CurrentState(filterHcdPrefix, StateName("testStateName"), Set(choiceKey.set(initChoice))))
-    // #currentStatePublisher
 
   }
 

--- a/csw-framework/src/test/scala/csw/common/components/command/ComponentHandlerForCommand.scala
+++ b/csw-framework/src/test/scala/csw/common/components/command/ComponentHandlerForCommand.scala
@@ -82,10 +82,8 @@ class ComponentHandlerForCommand(ctx: ActorContext[TopLevelActorMessage], cswCtx
     }
 
   private def processCurrentStateOneway(controlCommand: ControlCommand): Unit = {
-    // #subscribeCurrentState
     val currentState = CurrentState(prefix, StateName("HCDState"), controlCommand.paramSet)
     cswCtx.currentStatePublisher.publish(currentState)
-    // #subscribeCurrentState
   }
 
   private def processAcceptedSubmitCmd(cancelCommandId: Id, cancelCommandSetup: Setup): SubmitResponse = {

--- a/csw-framework/src/test/scala/csw/common/components/command/McsAssemblyComponentHandlers.scala
+++ b/csw-framework/src/test/scala/csw/common/components/command/McsAssemblyComponentHandlers.scala
@@ -70,7 +70,6 @@ class McsAssemblyComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswC
     }
   }
 
-  // #queryF
   private def processLongRunningCommand(prunId: Id, controlCommand: ControlCommand): Unit = {
     // Could be different components, can't actually submit parallel commands to an HCD
     val shortSetup  = Setup(assemblyPrefix, shortRunning, None)
@@ -123,7 +122,6 @@ class McsAssemblyComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswC
       }
     }
   }
-  // #queryF
 
   override def onOneway(runId: Id, controlCommand: ControlCommand): Unit = {}
 

--- a/csw-framework/src/test/scala/csw/common/components/command/McsHcdComponentHandlers.scala
+++ b/csw-framework/src/test/scala/csw/common/components/command/McsHcdComponentHandlers.scala
@@ -30,7 +30,6 @@ class McsHcdComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
     }
   }
 
-  // #updateCommand
   override def onSubmit(runId: Id, controlCommand: ControlCommand): SubmitResponse = {
     controlCommand.commandName match {
       case `longRunning` =>
@@ -38,7 +37,6 @@ class McsHcdComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
           commandResponseManager.updateCommand(Completed(runId))
         }
         Started(runId)
-      // #updateCommand
       case `mediumRunning` =>
         timeServiceScheduler.scheduleOnce(UTCTime(UTCTime.now().value.plusSeconds(3))) {
           commandResponseManager.updateCommand(Completed(runId))

--- a/csw-framework/src/test/scala/csw/common/components/framework/SampleComponentHandlers.scala
+++ b/csw-framework/src/test/scala/csw/common/components/framework/SampleComponentHandlers.scala
@@ -34,10 +34,8 @@ class SampleComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
     log.info("Initializing Component TLA")
     Thread.sleep(100)
 
-    // #currentStatePublisher
     // Publish the CurrentState using parameter set created using a sample Choice parameter
     currentStatePublisher.publish(CurrentState(prefix, StateName("testStateName"), Set(choiceKey.set(initChoice))))
-    // #currentStatePublisher
 
     // DEOPSCSW-219: Discover component connection using HTTP protocol
     trackConnection(httpConnection)
@@ -110,7 +108,6 @@ class SampleComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
     Thread.sleep(500)
   }
 
-  // #onDiagnostic-mode
   // While dealing with mutable state, make sure you create a worker actor to avoid concurrency issues
   // For functionality demonstration, we have simply used a mutable variable without worker actor
   var diagModeCancellable: Option[Cancellable] = None
@@ -124,13 +121,10 @@ class SampleComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
       case _ =>
     }
   }
-  // #onDiagnostic-mode
 
-  // #onOperations-mode
   override def onOperationsMode(): Unit = {
     diagModeCancellable.foreach(_.cancel())
   }
-  // #onOperations-mode
 
   override def onLocationTrackingEvent(trackingEvent: TrackingEvent): Unit =
     trackingEvent match {

--- a/csw-framework/src/test/scala/csw/framework/integration/CommandHttpIntegrationTests.scala
+++ b/csw-framework/src/test/scala/csw/framework/integration/CommandHttpIntegrationTests.scala
@@ -139,14 +139,12 @@ class CommandHttpIntegrationTests extends FrameworkIntegrationSuite {
     val submitAllSetup2       = Setup(seqPrefix, longRunningCmd, obsId)
     val submitAllinvalidSetup = Setup(seqPrefix, invalidCmd, obsId)
 
-    // #submitAll
     val submitAllF        = filterAssemblyCS.submitAllAndWait(List(submitAllSetup1, submitAllSetup2, submitAllinvalidSetup))
     val submitAllResponse = Await.result(submitAllF, timeout.duration)
     submitAllResponse.length shouldBe 3
     submitAllResponse(0) shouldBe a[Completed]
     submitAllResponse(1) shouldBe a[Completed]
     submitAllResponse(2) shouldBe a[Invalid]
-    // #submitAll
 
     // Make sure we can return a result
     val k1 = KeyType.IntKey.make("encoder")

--- a/csw-framework/src/test/scala/csw/framework/integration/CommandIntegrationTests.scala
+++ b/csw-framework/src/test/scala/csw/framework/integration/CommandIntegrationTests.scala
@@ -183,14 +183,12 @@ class CommandIntegrationTests extends FrameworkIntegrationSuite {
     val submitAllSetup2       = Setup(seqPrefix, longRunningCmd, obsId)
     val submitAllinvalidSetup = Setup(seqPrefix, invalidCmd, obsId)
 
-    // #submitAll
     val submitAllF        = filterAssemblyCS.submitAllAndWait(List(submitAllSetup1, submitAllSetup2, submitAllinvalidSetup))
     val submitAllResponse = Await.result(submitAllF, timeout.duration)
     submitAllResponse.length shouldBe 3
     submitAllResponse(0) shouldBe a[Completed]
     submitAllResponse(1) shouldBe a[Completed]
     submitAllResponse(2) shouldBe a[Invalid]
-    // #submitAll
 
     // Make sure we can return a result
     val k1 = KeyType.IntKey.make("encoder")

--- a/docs/src/main/_template/assets/custom.css
+++ b/docs/src/main/_template/assets/custom.css
@@ -1,0 +1,17 @@
+.snippet-button {
+    float: right;
+    vertical-align: middle;
+    padding: 0.25em 0.25em;
+    border: 1px solid #ddd;
+    margin: 0.25em;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.copy-snippet {
+    visibility: hidden;
+}
+
+.snippet-button:hover {
+    background: #c5cae9;
+}

--- a/docs/src/main/commons/apps.md
+++ b/docs/src/main/commons/apps.md
@@ -25,7 +25,7 @@ Docker setup is installed and running before starting the Elastic stack. To know
 
 For the host setup, follow the below given steps:
 
-* Install [Docker](https://www.docker.com/products/container-runtime) version **18.09+**
+* Install [Docker](https://www.docker.com/products/container-runtime/) version **18.09+**
 * Install [Docker Compose](https://docs.docker.com/compose/install/) version **1.24.0+**
 
 On distributions which have SELinux enabled out-of-the-box, you will need to either re-context the files or set SELinux

--- a/docs/src/main/commons/command.md
+++ b/docs/src/main/commons/command.md
@@ -217,7 +217,7 @@ Scala/submit w/invalid response
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #invalidCmd }
 
 Java/submit w/invalid response
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #invalidSubmitCmd }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #invalidSubmitCmd }
 
 The handling an immediate completion command looks the same from the command sender's perspective, but can be challenging on the side of the
 component handling the command. Because `submit` returns a `Future[SubmitResponse]` and `onSetup` returns `SubmitResponse`, an immediate completion
@@ -246,7 +246,7 @@ Scala/submitAndWait w/immediate-response
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #immediate-response }
 
 Java/submitAndWait w/immediate-response
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #immediate-response }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #immediate-response }
 
 Several examples have been shown of sending a command that is long-running. The following examples show an Assembly that issues a
 command to an HCD with `submitAndWait` and returns `Started`. When `submitAndWait` returns with a final response, the parent is updated
@@ -256,7 +256,7 @@ Scala/submitAndWait w/immediate-response
 :   @@snip [CurrentStateExampleComponentHandlers.scala](../../../../examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala) { #longRunning }
 
 Java/submitAndWait w/immediate-response
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #longRunning }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #longRunning }
 
 ### oneway
 
@@ -271,7 +271,7 @@ Scala
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #oneway }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #oneway }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #oneway }
 
 ### validate
 
@@ -282,7 +282,7 @@ Scala
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #validate }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #validate }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #validate }
 
 ### query
 
@@ -295,7 +295,7 @@ Scala/submit w/query
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #queryLongRunning }
 
 Java/submit w/query
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryLongRunning }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryLongRunning }
 
 ### queryFinal
 
@@ -310,7 +310,7 @@ Scala/submitAndWait long running/queryFinal
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #queryFinalWithSubmitAndWait }
 
 Java/submitAndWait long running/queryFinal
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryFinal }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryFinal }
 
 ### submitAllAndWait
 
@@ -325,7 +325,7 @@ Scala/query usage
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #submitAll }
 
 Java/query usage
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #submitAll }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #submitAll }
 
 In the first example, three commands are sent and the result is a list with three `SubmitResponse`s.
 The last one returned invalid and was not executed.
@@ -356,7 +356,7 @@ Scala
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #subscribeCurrentState }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #subscribeCurrentState }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #subscribeCurrentState }
 
 The second part of the example shows the code in the HCD. When the HCD receives the `oneway` message, it extracts
 the encoder value and publishes a CurrentState item with the encoder parameter.
@@ -396,10 +396,10 @@ The developer is not limited to these `StateMatcher`s. Any class the implements 
 interface can be provided to a `Matcher`.
   
 Scala
-:   @@snip [LongRunningCommandTest.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #matcher }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #matcher }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #matcher }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #matcher }
 
 One important point is that the `matcher` is created and must be shutdown when you are finished with it using
 the `stop` method of the matcher as shown in the example.
@@ -413,4 +413,4 @@ Scala
 :   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #onewayAndMatch }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #onewayAndMatch }
+:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #onewayAndMatch }

--- a/docs/src/main/commons/command.md
+++ b/docs/src/main/commons/command.md
@@ -214,10 +214,10 @@ is possible to handle an `Invalid` response locally, but in most cases it must s
 shows how to process individual responses from a `submit`:
 
 Scala/submit w/invalid response
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #invalidCmd }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #invalidCmd }
 
 Java/submit w/invalid response
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #invalidSubmitCmd }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #invalidSubmitCmd }
 
 The handling an immediate completion command looks the same from the command sender's perspective, but can be challenging on the side of the
 component handling the command. Because `submit` returns a `Future[SubmitResponse]` and `onSetup` returns `SubmitResponse`, an immediate completion
@@ -243,20 +243,20 @@ commands look the same from the command sender's perspective when using `submitA
 This example shows an immediate completion command using `submitAndWait`.
 
 Scala/submitAndWait w/immediate-response
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #immediate-response }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #immediate-response }
 
 Java/submitAndWait w/immediate-response
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #immediate-response }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #immediate-response }
 
 Several examples have been shown of sending a command that is long-running. The following examples show an Assembly that issues a
 command to an HCD with `submitAndWait` and returns `Started`. When `submitAndWait` returns with a final response, the parent is updated
 with the final response through the `CommandResponseManager`.
 
 Scala/submitAndWait w/immediate-response
-:   @@snip [CommandAssemblyHandlers.scala](../../../../csw-framework/src/test/scala/csw/common/components/command/CommandAssemblyHandlers.scala) { #longRunning }
+:   @@snip [CurrentStateExampleComponentHandlers.scala](../../../../examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala) { #longRunning }
 
 Java/submitAndWait w/immediate-response
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #longRunning }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #longRunning }
 
 ### oneway
 
@@ -268,10 +268,10 @@ Oneway is useful for communication between an Assembly when it needs to send com
 validated on the destination and the validation response is returned, but no other responses are provided.
 
 Scala
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #oneway }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #oneway }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #oneway }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #oneway }
 
 ### validate
 
@@ -279,10 +279,10 @@ Sometimes it may be useful to test whether or not a component can execute a comm
 actions. The `validate` message can be used for this purpose. `Validate` returns a `ValidateResponse` of `Accepted`, `Invalid`, or `Locked`.
 
 Scala
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #validate }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #validate }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #validate }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #validate }
 
 ### query
 
@@ -292,10 +292,10 @@ the `query` method of `CommandService` can be used as shown in the
 following example without using the Future returned by `submitAndWait`, which provides the final completion notification.
 
 Scala/submit w/query
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #queryLongRunning }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #queryLongRunning }
 
 Java/submit w/query
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #queryLongRunning }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryLongRunning }
 
 ### queryFinal
 
@@ -307,10 +307,10 @@ possible to just start actions with `submitAndWait` and use the returned Future 
 you can use the runId returned by `submitAndWait` with `queryFinal`.
 
 Scala/submitAndWait long running/queryFinal
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #queryFinalWithSubmitAndWait }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #queryFinalWithSubmitAndWait }
 
 Java/submitAndWait long running/queryFinal
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #queryFinal }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryFinal }
 
 ### submitAllAndWait
 
@@ -322,10 +322,10 @@ as a Future, `submitAllAndWait` returns a list of `SubmitResponse`s as a future,
 all the commands in the list have completed.
 
 Scala/query usage
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #submitAll }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #submitAll }
 
 Java/query usage
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #submitAll }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #submitAll }
 
 In the first example, three commands are sent and the result is a list with three `SubmitResponse`s.
 The last one returned invalid and was not executed.
@@ -353,19 +353,19 @@ The example sends a `Setup` with an encoder parameter value to the HCD as a `one
 causes the HCD to publish `CurrentState` with the value that was sent to it.
 
 Scala
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #subscribeCurrentState }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #subscribeCurrentState }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #subscribeCurrentState }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #subscribeCurrentState }
 
 The second part of the example shows the code in the HCD. When the HCD receives the `oneway` message, it extracts
 the encoder value and publishes a CurrentState item with the encoder parameter.
 
 Scala
-:   @@snip [ComponentHandlerForCommand.scala](../../../../csw-framework/src/test/scala/csw/common/components/command/ComponentHandlerForCommand.scala) { #subscribeCurrentState }
+:   @@snip [CurrentStateExampleComponentHandlers.scala](../../../../examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala) { #currentStatePublisher }
 
 Java
-:   @@snip [JSampleComponentHandlers.java](../../../../csw-framework/src/test/java/csw/framework/javadsl/components/JSampleComponentHandlers.java) { #subscribeCurrentState }
+:   @@snip [JCurrentStateExampleComponentHandlers.java](../../../../examples/src/main/java/org/tmt/csw/sample/JCurrentStateExampleComponentHandlers.java) { #currentStatePublisher }
 
 There are two `subscribeCurrentState` methods in `CommandService`. The method shown in the above examples subscribes
 the caller to *all* CurrentState published. Each `CurrentState` item has a `StateName`. A second signature for
@@ -396,10 +396,10 @@ The developer is not limited to these `StateMatcher`s. Any class the implements 
 interface can be provided to a `Matcher`.
   
 Scala
-:   @@snip [LongRunningCommandTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #matcher }
+:   @@snip [LongRunningCommandTest.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #matcher }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #matcher }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #matcher }
 
 One important point is that the `matcher` is created and must be shutdown when you are finished with it using
 the `stop` method of the matcher as shown in the example.
@@ -410,7 +410,7 @@ the `stop` method of the matcher as shown in the example.
  and implements much of the boilerplate of the previous example.
 
 Scala
-:   @@snip [CommandServiceTest.scala](../../../../integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala) { #onewayAndMatch }
+:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #onewayAndMatch }
 
 Java
-:   @@snip [JCommandIntegrationTest.java](../../../../csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java) { #onewayAndMatch }
+:   @@snip [JCommandIntegrationTest.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #onewayAndMatch }

--- a/docs/src/main/commons/command.md
+++ b/docs/src/main/commons/command.md
@@ -214,10 +214,10 @@ is possible to handle an `Invalid` response locally, but in most cases it must s
 shows how to process individual responses from a `submit`:
 
 Scala/submit w/invalid response
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #invalidCmd }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #invalidCmd }
 
 Java/submit w/invalid response
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #invalidSubmitCmd }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #invalidSubmitCmd }
 
 The handling an immediate completion command looks the same from the command sender's perspective, but can be challenging on the side of the
 component handling the command. Because `submit` returns a `Future[SubmitResponse]` and `onSetup` returns `SubmitResponse`, an immediate completion
@@ -243,10 +243,10 @@ commands look the same from the command sender's perspective when using `submitA
 This example shows an immediate completion command using `submitAndWait`.
 
 Scala/submitAndWait w/immediate-response
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #immediate-response }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #immediate-response }
 
 Java/submitAndWait w/immediate-response
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #immediate-response }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #immediate-response }
 
 Several examples have been shown of sending a command that is long-running. The following examples show an Assembly that issues a
 command to an HCD with `submitAndWait` and returns `Started`. When `submitAndWait` returns with a final response, the parent is updated
@@ -256,7 +256,7 @@ Scala/submitAndWait w/immediate-response
 :   @@snip [CurrentStateExampleComponentHandlers.scala](../../../../examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala) { #longRunning }
 
 Java/submitAndWait w/immediate-response
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #longRunning }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #longRunning }
 
 ### oneway
 
@@ -268,10 +268,10 @@ Oneway is useful for communication between an Assembly when it needs to send com
 validated on the destination and the validation response is returned, but no other responses are provided.
 
 Scala
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #oneway }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #oneway }
 
 Java
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #oneway }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #oneway }
 
 ### validate
 
@@ -279,10 +279,10 @@ Sometimes it may be useful to test whether or not a component can execute a comm
 actions. The `validate` message can be used for this purpose. `Validate` returns a `ValidateResponse` of `Accepted`, `Invalid`, or `Locked`.
 
 Scala
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #validate }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #validate }
 
 Java
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #validate }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #validate }
 
 ### query
 
@@ -292,10 +292,10 @@ the `query` method of `CommandService` can be used as shown in the
 following example without using the Future returned by `submitAndWait`, which provides the final completion notification.
 
 Scala/submit w/query
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #queryLongRunning }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #queryLongRunning }
 
 Java/submit w/query
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryLongRunning }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #queryLongRunning }
 
 ### queryFinal
 
@@ -307,10 +307,10 @@ possible to just start actions with `submitAndWait` and use the returned Future 
 you can use the runId returned by `submitAndWait` with `queryFinal`.
 
 Scala/submitAndWait long running/queryFinal
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #queryFinalWithSubmitAndWait }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #queryFinalWithSubmitAndWait }
 
 Java/submitAndWait long running/queryFinal
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #queryFinal }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #queryFinal }
 
 ### submitAllAndWait
 
@@ -322,10 +322,10 @@ as a Future, `submitAllAndWait` returns a list of `SubmitResponse`s as a future,
 all the commands in the list have completed.
 
 Scala/query usage
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #submitAll }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #submitAll }
 
 Java/query usage
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #submitAll }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #submitAll }
 
 In the first example, three commands are sent and the result is a list with three `SubmitResponse`s.
 The last one returned invalid and was not executed.
@@ -353,10 +353,10 @@ The example sends a `Setup` with an encoder parameter value to the HCD as a `one
 causes the HCD to publish `CurrentState` with the value that was sent to it.
 
 Scala
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #subscribeCurrentState }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #subscribeCurrentState }
 
 Java
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #subscribeCurrentState }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #subscribeCurrentState }
 
 The second part of the example shows the code in the HCD. When the HCD receives the `oneway` message, it extracts
 the encoder value and publishes a CurrentState item with the encoder parameter.
@@ -396,10 +396,10 @@ The developer is not limited to these `StateMatcher`s. Any class the implements 
 interface can be provided to a `Matcher`.
   
 Scala
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #matcher }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #matcher }
 
 Java
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #matcher }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #matcher }
 
 One important point is that the `matcher` is created and must be shutdown when you are finished with it using
 the `stop` method of the matcher as shown in the example.
@@ -410,7 +410,7 @@ the `stop` method of the matcher as shown in the example.
  and implements much of the boilerplate of the previous example.
 
 Scala
-:   @@snip [CommandExample.scala](../../../../examples/src/test/scala/example/command/CommandExample.scala) { #onewayAndMatch }
+:   @@snip [CommandServiceExample.scala](../../../../examples/src/test/scala/example/command/CommandServiceExample.scala) { #onewayAndMatch }
 
 Java
-:   @@snip [JCommandExample.java](../../../../examples/src/test/java/example/command/JCommandExample.java) { #onewayAndMatch }
+:   @@snip [JCommandServiceExample.java](../../../../examples/src/test/java/example/command/JCommandServiceExample.java) { #onewayAndMatch }

--- a/docs/src/main/commons/testing.md
+++ b/docs/src/main/commons/testing.md
@@ -35,10 +35,10 @@ When you really want granular level access to testkits, then only you would want
 You can create instance of `FrameworkTestKit` as shown below:
 
 Scala
-:   @@snip [TestKitsExampleTest.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExampleTest.scala) { #framework-testkit }
+:   @@snip [TestKitsExample.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExample.scala) { #framework-testkit }
 
 Java
-:   @@snip [TestKitsExampleTest.scala](../../../../examples/src/test/java/example/testkit/JTestKitsExampleTest.java) { #framework-testkit }
+:   @@snip [TestKitsExample.scala](../../../../examples/src/test/java/example/testkit/JTestKitsExample.java) { #framework-testkit }
 
 @@@ note
 
@@ -66,27 +66,27 @@ Use the `spawnContainer` method provided by `FrameworkTestKit` to start componen
 The example below shows how to spawn container or component in standalone mode using the Framework testkit.
 
 Scala
-:   @@snip [TestKitsExampleTest.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExampleTest.scala) { #spawn-using-testkit }
+:   @@snip [TestKitsExample.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExample.scala) { #spawn-using-testkit }
 
 Java
-:   @@snip [JTestKitsExampleTest.scala](../../../../examples/src/test/java/example/testkit/JTestKitsExampleTest.java) { #spawn-using-testkit }
+:   @@snip [JTestKitsExample.scala](../../../../examples/src/test/java/example/testkit/JTestKitsExample.java) { #spawn-using-testkit }
 
 Other ways to spawn Assembly and HCD in the standalone mode using Framework testkit.
 
 ## Spawning a HCD
 
 Scala
-:   @@snip [TestKitsExampleTest.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExampleTest.scala) { #spawn-hcd }
+:   @@snip [TestKitsExample.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExample.scala) { #spawn-hcd }
 
 ## Spawning an Assembly
 
 Scala
-:   @@snip [TestKitsExampleTest.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExampleTest.scala) { #spawn-assembly }
+:   @@snip [TestKitsExample.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExample.scala) { #spawn-assembly }
 
 Full source at GitHub
 
-- [Scala]($github.base_url$/examples/src/test/scala/example/teskit/TestKitsExampleTest.scala)
-- [Java]($github.base_url$/examples/src/test/java/example/testkit/JTestKitsExampleTest.java)
+- [Scala]($github.base_url$/examples/src/test/scala/example/teskit/TestKitsExample.scala)
+- [Java]($github.base_url$/examples/src/test/java/example/testkit/JTestKitsExample.java)
 
 ## Test Framework Integration
 
@@ -114,10 +114,10 @@ If you are using JUnit then you can use `csw.testkit.javadsl.FrameworkTestKitJun
 The example below shows the usage of `ScalaTestFrameworkTestKit` and `FrameworkTestKitJunitResource` and how you can start the above mentioned services as per your need.
 
 Scala
-:   @@snip [ScalaTestExampleIntegrationTest.scala](../../../../examples/src/test/scala/example/teskit/ScalaTestIntegrationExampleTest.scala) { #scalatest-testkit }
+:   @@snip [ScalaTestExampleIntegration.scala](../../../../examples/src/test/scala/example/teskit/ScalaTestIntegrationExample.scala) { #scalatest-testkit }
 
 Java
-:   @@snip [JUnitIntegrationExampleTest.scala](../../../../examples/src/test/java/example/testkit/JUnitIntegrationExampleTest.java) { #junit-testkit }
+:   @@snip [JUnitIntegrationExample.scala](../../../../examples/src/test/java/example/testkit/JUnitIntegrationExample.java) { #junit-testkit }
 
 @@@ note
 
@@ -139,10 +139,10 @@ an alarm for testing purposes.
 The example below shows the usage `initAlarms` & `getCurrentSeverity` methods using `AlarmTestKit`.
 
 Scala
-: @@snip [ScalaAlarmTestKitExampleTest.scala](../../../../examples/src/test/scala/example/teskit/ScalaAlarmTestKitExampleTest.scala) { #scalatest-alarm-testkit }
+: @@snip [ScalaAlarmTestKitExample.scala](../../../../examples/src/test/scala/example/teskit/ScalaAlarmTestKitExample.scala) { #scalatest-alarm-testkit }
 
 Java
-:   @@snip [JUnitAlarmTestKitExampleTest.scala](../../../../examples/src/test/java/example/testkit/JUnitAlarmTestKitExampleTest.java) { #junit-alarm-testkit }
+:   @@snip [JUnitAlarmTestKitExample.scala](../../../../examples/src/test/java/example/testkit/JUnitAlarmTestKitExample.java) { #junit-alarm-testkit }
 
 ### Using dslContext provided by DatabaseTestKit
 
@@ -153,10 +153,10 @@ The `DatabaseTestKit` also provides methods to create database client and execut
 The example below shows the usage `dslContext` & `databaseServiceFactory` methods using `DatabaseTestKit`.
 
 Scala
-: @@snip [ScalaDatabaseTestKitExampleTest.scala](../../../../examples/src/test/scala/example/teskit/ScalaDatabaseTestKitExampleTest.scala) { #scalatest-database-testkit }
+: @@snip [ScalaDatabaseTestKitExample.scala](../../../../examples/src/test/scala/example/teskit/ScalaDatabaseTestKitExample.scala) { #scalatest-database-testkit }
 
 Java
-:   @@snip [JUnitDatabaseTestKitExampleTest.scala](../../../../examples/src/test/java/example/testkit/JUnitDatabaseTestKitExampleTest.java) { #junit-database-testkit }
+:   @@snip [JUnitDatabaseTestKitExample.scala](../../../../examples/src/test/java/example/testkit/JUnitDatabaseTestKitExample.java) { #junit-database-testkit }
 
 ## Unit Tests
 

--- a/docs/src/main/commons/testing.md
+++ b/docs/src/main/commons/testing.md
@@ -69,7 +69,7 @@ Scala
 :   @@snip [TestKitsExampleTest.scala](../../../../examples/src/test/scala/example/teskit/TestKitsExampleTest.scala) { #spawn-using-testkit }
 
 Java
-:   @@snip [TestKitsExampleTest.scala](../../../../examples/src/test/java/example/testkit/JTestKitsExampleTest.java) { #spawn-using-testkit }
+:   @@snip [JTestKitsExampleTest.scala](../../../../examples/src/test/java/example/testkit/JTestKitsExampleTest.java) { #spawn-using-testkit }
 
 Other ways to spawn Assembly and HCD in the standalone mode using Framework testkit.
 

--- a/docs/src/main/commons/unit-tests.md
+++ b/docs/src/main/commons/unit-tests.md
@@ -35,7 +35,7 @@ started in the superclass's `beforeAll` method. In the Java version, we must cre
 services we want to start passed into the constructor of this object.
 
 Scala
-:   @@snip [AssemblyTest.scala](../../../../examples/src/test/scala/org/tmt/csw/sample/SampleTest.scala) { #intro }
+:   @@snip [SampleTest.scala](../../../../examples/src/test/scala/org/tmt/csw/sample/SampleTest.scala) { #intro }
 
 Java
 :   @@snip [JSampleAssemblyTest.java](../../../../examples/src/test/java/org/tmt/csw/sample/JSampleTest.java) { #intro }
@@ -144,12 +144,12 @@ Scala
 Spawning an Assembly
 
 Scala
-:   @@snip [AssemblyTest.scala](../../../../examples/src/test/scala/org/tmt/csw/sample/SampleTest.scala) { #spawn-assembly }
+:   @@snip [SampleTest.scala](../../../../examples/src/test/scala/org/tmt/csw/sample/SampleTest.scala) { #spawn-assembly }
 
 ### Spawning a Component using DefaultComponentHandlers
 
 Scala
-:   @@snip [AssemblyTest.scala](../../../../examples/src/test/scala/org/tmt/csw/sample/SampleTest.scala) { #spawn-assembly-with-default-handlers }
+:   @@snip [SampleTest.scala](../../../../examples/src/test/scala/org/tmt/csw/sample/SampleTest.scala) { #spawn-assembly-with-default-handlers }
 
 Full source at GitHub
 

--- a/docs/src/main/framework/creating-components.md
+++ b/docs/src/main/framework/creating-components.md
@@ -27,13 +27,13 @@ Hcd/Java
 Examples for case 2:
 
 Assembly/Scala
-:   @@snip [AssemblyComponentHandlers.scala](../../../../examples/src/main/scala/example/framework/components/assembly/TCSAssemblyCompHandlers.scala) { #component-handlers-class }
+:   @@snip [TCSAssemblyCompHandlers.scala](../../../../examples/src/main/scala/example/framework/components/assembly/TCSAssemblyCompHandlers.scala) { #component-handlers-class }
 
 Assembly/Java
-:   @@snip [JAssemblyComponentHandlers.java](../../../../examples/src/main/java/example/framework/components/assembly/JTCSAssemblyCompHandlers.java) { #jcomponent-handlers-class }
+:   @@snip [JTCSAssemblyCompHandlers.java](../../../../examples/src/main/java/example/framework/components/assembly/JTCSAssemblyCompHandlers.java) { #jcomponent-handlers-class }
 
 Hcd/Scala
-:   @@snip [HcdComponentHandlers.scala](../../../../examples/src/main/scala/example/framework/components/hcd/TCSHcdCompHandlers.scala) { #component-handlers-class }
+:   @@snip [TCSHcdCompHandlers.scala](../../../../examples/src/main/scala/example/framework/components/hcd/TCSHcdCompHandlers.scala) { #component-handlers-class }
 
 Hcd/Java
 :   @@snip [JHcdComponentHandlers.java](../../../../examples/src/main/java/example/framework/components/hcd/JTCSHcdCompHandlers.java) { #jcomponent-handlers-class }

--- a/docs/src/main/framework/handling-lifecycle.md
+++ b/docs/src/main/framework/handling-lifecycle.md
@@ -269,10 +269,10 @@ Unsupported hints should be rejected by a component.
 The example shows one usage of `onDiagnosticMode` handler.
 
 Scala
-:   @@snip [SampleComponentHandlers.scala](../../../../csw-framework/src/test/scala/csw/common/components/framework/SampleComponentHandlers.scala) { #onDiagnostic-mode }
+:   @@snip [SampleComponentHandlers.scala](../../../../examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala) { #onDiagnostic-mode }
 
 Java
-:   @@snip [JSampleComponentHandlers.java](../../../../csw-framework/src/test/java/csw/framework/javadsl/components/JSampleComponentHandlers.java) { #onDiagnostic-mode }
+:   @@snip [JSampleComponentHandlers.java](../../../../examples/src/main/java/org/tmt/csw/sample/JCurrentStateExampleComponentHandlers.java) { #onDiagnostic-mode }
 
 ### onOperationsMode
 
@@ -286,7 +286,7 @@ process an `onOperationsMode` handler call. The component should return completi
 The example shows one usage of `onOperationsMode` handler.
 
 Scala
-:   @@snip [SampleComponentHandlers.scala](../../../../csw-framework/src/test/scala/csw/common/components/framework/SampleComponentHandlers.scala) { #onOperations-mode }
+:   @@snip [SampleComponentHandlers.scala](../../../../examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala) { #onOperations-mode }
 
 Java
-:   @@snip [JSampleComponentHandlers.java](../../../../csw-framework/src/test/java/csw/framework/javadsl/components/JSampleComponentHandlers.java) { #onOperations-mode }
+:   @@snip [JSampleComponentHandlers.java](../../../../examples/src/main/java/org/tmt/csw/sample/JCurrentStateExampleComponentHandlers.java) { #onOperations-mode }

--- a/docs/src/main/framework/managing-command-state.md
+++ b/docs/src/main/framework/managing-command-state.md
@@ -56,7 +56,7 @@ sub-commands to finish. In the `OverallSuccess` case `commandResponseManager.upd
 If one or more of the sub-commands fails, the negative response of the first failed command is returned to the parent.
 
 Scala
-:   @@snip [McsAssemblyComponentHandlers.scala](../../../../examples/src/main/scala/example/tutorial/basic/sampleassembly/SampleAssemblyHandlers.scala) { #queryF }
+:   @@snip [SampleAssemblyHandlers.scala](../../../../examples/src/main/scala/example/tutorial/basic/sampleassembly/SampleAssemblyHandlers.scala) { #queryF }
 
 Java
 :   @@snip [JCommandIntegrationTest.java](../../../../examples/src/main/java/example/tutorial/basic/sampleassembly/JSampleAssemblyHandlers.java) { #queryF }

--- a/docs/src/main/framework/publishing-state.md
+++ b/docs/src/main/framework/publishing-state.md
@@ -22,7 +22,7 @@ A subscriber can subscribe to all `CurrentState` published by an HCD or to speci
 `StateName`. The publisher does not need to do anything special to support these features.
 
 Scala
-:   @@snip [SampleComponentHandlers.scala](../../../../csw-framework/src/test/scala/csw/common/components/framework/SampleComponentHandlers.scala) { #currentStatePublisher }
+:   @@snip [SampleComponentHandlers.scala](../../../../examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala) { #currentStatePublisher }
 
 Java
-:   @@snip [JSampleComponentHandlers.java](../../../../csw-framework/src/test/java/csw/framework/javadsl/components/JSampleComponentHandlers.java) { #currentStatePublisher }
+:   @@snip [JSampleComponentHandlers.java](../../../../examples/src/main/java/org/tmt/csw/sample/JCurrentStateExampleComponentHandlers.java) { #currentStatePublisher }

--- a/docs/src/main/params/commands.md
+++ b/docs/src/main/params/commands.md
@@ -10,10 +10,10 @@ An `ObsID`, or observation ID, indicates the observation the command is associat
 It can be constructed by creating an instance of `ObsId`. 
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #obsid }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #obsid }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #obsid }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #obsid }
 
 ## Prefix
 
@@ -25,10 +25,10 @@ An example of a valid string prefix is "nfiraos.ncc.trombone".
 See below examples:
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #prefix }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #prefix }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #prefix }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #prefix }
 
 ## CommandName
 
@@ -47,10 +47,10 @@ following arguments to create a `Setup` command.
  * **paramSet:** Optional Set of Parameters. Default is empty.
  
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #setup }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #setup }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #setup }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #setup }
  
  
 ## Observe Command
@@ -58,29 +58,29 @@ Java
 This command describes a science observation. It is intended to only be sent to Science Detector Assemblies and Sequencers.
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #observe }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #observe }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #observe }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #observe }
 
 ## Wait Command
 
 This command causes a Sequencer to wait until notified.  It can only be sent to Sequencers.
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #wait }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #wait }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #wait }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #wait }
 
 ## JSON serialization
 Commands can be serialized to JSON. The library has provided **JsonSupport** helper class and methods to serialize Setup, Observe and Wait commands.
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #json-serialization }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #json-serialization }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #json-serialization }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #json-serialization }
 
 ## Unique Key constraint
 
@@ -98,10 +98,10 @@ parameters based on key.
 Here are some examples that illustrate this point:
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #unique-key }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #unique-key }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #unique-key }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #unique-key }
 
 ## Cloning a Command
 
@@ -110,13 +110,13 @@ If you wish to resubmit a previously sent Setup, the `cloneCommand` method must 
 to create a new command from existing parameters, but with a new `RunId`.
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/CommandsTest.scala) { #clone-command }
+:   @@snip [CommandsExample.scala](../../../../examples/src/test/scala/example/params/CommandsExample.scala) { #clone-command }
 
 Java
-:   @@snip [JCommandsTest.java](../../../../examples/src/test/java/example/params/JCommandsTest.java) { #clone-command }
+:   @@snip [JCommandsExample.java](../../../../examples/src/test/java/example/params/JCommandsExample.java) { #clone-command }
 
 
 # Source Code for Examples
 
-* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/CommandsTest.scala)
-* [Java Example]($github.base_url$/examples/src/test/java/example/params/JCommandsTest.java)
+* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/CommandsExample.scala)
+* [Java Example]($github.base_url$/examples/src/test/java/example/params/JCommandsExample.java)

--- a/docs/src/main/params/events.md
+++ b/docs/src/main/params/events.md
@@ -19,10 +19,10 @@ For more on Cbor, refer to the @ref:[technical doc](../technical/params/params.m
 Each event includes its time of creation in UTC format. You can access that eventTime as follows:
 
 Scala
-: @@snip [EventsTest.scala](../../../../examples/src/test/scala/example/params/EventsTest.scala) { #eventtime }
+: @@snip [EventsExample.scala](../../../../examples/src/test/scala/example/params/EventsExample.scala) { #eventtime }
 
 Java
-: @@snip [JEventsTest.java](../../../../examples/src/test/java/example/params/JEventsTest.java) { #eventtime }
+: @@snip [JEventsExample.java](../../../../examples/src/test/java/example/params/JEventsExample.java) { #eventtime }
 
 ## System Event
 
@@ -31,10 +31,10 @@ the output of an algorithm in one component that is used as an input to another.
 to publish internal state or status values of a component that may be of interest to other components in the system.
 
 Scala
-:   @@snip [EventsTest.scala](../../../../examples/src/test/scala/example/params/EventsTest.scala) { #systemevent }
+:   @@snip [EventsExample.scala](../../../../examples/src/test/scala/example/params/EventsExample.scala) { #systemevent }
 
 Java
-:   @@snip [JEventsTest.java](../../../../examples/src/test/java/example/params/JEventsTest.java) { #systemevent }
+:   @@snip [JEventsExample.java](../../../../examples/src/test/java/example/params/JEventsExample.java) { #systemevent }
 
 ## Observe Event
 
@@ -249,20 +249,20 @@ The downtime will be started by the downtimeStart event and ended by the next ob
 The following snippet shows how to create a observe event
 
 Scala
-:   @@snip [EventsTest.scala](../../../../examples/src/test/scala/example/params/EventsTest.scala) { #observe-event }
+:   @@snip [EventsExample.scala](../../../../examples/src/test/scala/example/params/EventsExample.scala) { #observe-event }
 
 Java
-:   @@snip [JEventsTest.java](../../../../examples/src/test/java/example/params/JEventsTest.java) { #observe-event }
+:   @@snip [JEventsExample.java](../../../../examples/src/test/java/example/params/JEventsExample.java) { #observe-event }
 
 ## JSON Serialization
 
 Events can be serialized to JSON. The library has provided **JsonSupport** helper class and methods to serialize Status, Observe and System events.
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/EventsTest.scala) { #json-serialization }
+:   @@snip [EventsExample.scala](../../../../examples/src/test/scala/example/params/EventsExample.scala) { #json-serialization }
 
 Java
-:   @@snip [JEventsTest.java](../../../../examples/src/test/java/example/params/JEventsTest.java) { #json-serialization }
+:   @@snip [JEventsExample.java](../../../../examples/src/test/java/example/params/JEventsExample.java) { #json-serialization }
 
 ## Unique Key Constraint
 
@@ -280,7 +280,7 @@ parameters based on key.
 Here are some examples that illustrate this point:
 
 Scala
-:   @@snip [CommandsTest.scala](../../../../examples/src/test/scala/example/params/EventsTest.scala) { #unique-key }
+:   @@snip [EventsExample.scala](../../../../examples/src/test/scala/example/params/EventsExample.scala) { #unique-key }
 
 Java
-:   @@snip [JEventsTest.java](../../../../examples/src/test/java/example/params/JEventsTest.java) { #unique-key }
+:   @@snip [JEventsExample.java](../../../../examples/src/test/java/example/params/JEventsExample.java) { #unique-key }

--- a/docs/src/main/params/keys-parameters.md
+++ b/docs/src/main/params/keys-parameters.md
@@ -36,10 +36,10 @@ A key is **unique** in a `ParameterSet` since it is a Set.
 | TaiTime         | KeyType.TAITimeKey          | JKeyType.TAITimeKey           |
 
 Scala
-:   @@snip [KeysAndParametersTest.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersTest.scala) { #primitives }
+:   @@snip [KeysAndParametersExample.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersExample.scala) { #primitives }
 
 Java
-:   @@snip [JKeysAndParametersTest.java](../../../../examples/src/test/java/example/params/JKeysAndParametersTest.java) { #primitives }
+:   @@snip [JKeysAndParametersExample.java](../../../../examples/src/test/java/example/params/JKeysAndParametersExample.java) { #primitives }
 
 ## Arrays
 
@@ -53,10 +53,10 @@ Java
 | DoubleArray     | KeyType.DoubleArrayKey      | JKeyType.DoubleArrayKey       |
 
 Scala
-:   @@snip [KeysAndParametersTest.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersTest.scala) { #arrays }
+:   @@snip [KeysAndParametersExample.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersExample.scala) { #arrays }
 
 Java
-:   @@snip [JKeysAndParametersTest.java](../../../../examples/src/test/java/example/params/JKeysAndParametersTest.java) { #arrays }
+:   @@snip [JKeysAndParametersExample.java](../../../../examples/src/test/java/example/params/JKeysAndParametersExample.java) { #arrays }
 
 ## Matrices
 
@@ -70,10 +70,10 @@ Java
 | DoubleMatrix    | KeyType.DoubleMatrixKey     | JKeyType.DoubleMatrixKey      |
 
 Scala
-:   @@snip [KeysAndParametersTest.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersTest.scala) { #matrices }
+:   @@snip [KeysAndParametersExample.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersExample.scala) { #matrices }
 
 Java
-:   @@snip [JKeysAndParametersTest.java](../../../../examples/src/test/java/example/params/JKeysAndParametersTest.java) { #matrices }
+:   @@snip [JKeysAndParametersExample.java](../../../../examples/src/test/java/example/params/JKeysAndParametersExample.java) { #matrices }
 
 
 ## Domain Specific Types
@@ -105,10 +105,10 @@ the key for any of the coordinate types.
 The following example demonstrates the basic usage of the coordinate parameter types:
 
 Scala
-:   @@snip [KeysAndParametersTest.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersTest.scala) { #coords }
+:   @@snip [KeysAndParametersExample.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersExample.scala) { #coords }
 
 Java
-:   @@snip [JKeysAndParametersTest.java](../../../../examples/src/test/java/example/params/JKeysAndParametersTest.java) { #coords }
+:   @@snip [JKeysAndParametersExample.java](../../../../examples/src/test/java/example/params/JKeysAndParametersExample.java) { #coords }
 
 ### Struct
 
@@ -119,13 +119,13 @@ Struct got removed in 4.0.0 version.
 A key for a choice item similar to an enumeration.
 
 Scala
-:   @@snip [KeysAndParametersTest.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersTest.scala) { #choice }
+:   @@snip [KeysAndParametersExample.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersExample.scala) { #choice }
 
 Java
-:   @@snip [JKeysAndParametersTest.java](../../../../examples/src/test/java/example/params/JKeysAndParametersTest.java) { #choice }
+:   @@snip [JKeysAndParametersExample.java](../../../../examples/src/test/java/example/params/JKeysAndParametersExample.java) { #choice }
 
 
 ## Source Code for Examples
 
-* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/KeysAndParametersTest.scala)
-* [Java Example]($github.base_url$/examples/src/test/java/example/params/JKeysAndParametersTest.java)
+* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/KeysAndParametersExample.scala)
+* [Java Example]($github.base_url$/examples/src/test/java/example/params/JKeysAndParametersExample.java)

--- a/docs/src/main/params/result.md
+++ b/docs/src/main/params/result.md
@@ -9,19 +9,19 @@ Creating a Result Requires:
  * **[Set[Parameter]](keys-parameters.html)**
 
 Scala
-:   @@snip [ResultTest.scala](../../../../examples/src/test/scala/example/params/ResultTest.scala) { #result }
+:   @@snip [ResultExample.scala](../../../../examples/src/test/scala/example/params/ResultExample.scala) { #result }
 
 Java
-:   @@snip [JResultTest.java](../../../../examples/src/test/java/example/params/JResultTest.java) { #result }
+:   @@snip [JResultExample.java](../../../../examples/src/test/java/example/params/JResultExample.java) { #result }
 
 ## JSON serialization
 State variables can be serialized to JSON. The library has provided **JsonSupport** helper class and methods to serialize DemandState and CurrentState.
 
 Scala
-:   @@snip [ResultTest.scala](../../../../examples/src/test/scala/example/params/ResultTest.scala) { #json-serialization }
+:   @@snip [ResultExample.scala](../../../../examples/src/test/scala/example/params/ResultExample.scala) { #json-serialization }
 
 Java
-:   @@snip [JResultTest.java](../../../../examples/src/test/java/example/params/JResultTest.java) { #json-serialization }
+:   @@snip [JResultExample.java](../../../../examples/src/test/java/example/params/JResultExample.java) { #json-serialization }
 
 ## Unique Key Constraint
 
@@ -36,12 +36,12 @@ Parameters are stored in a Set, which is an unordered collection of items. Hence
 Here are some examples that illustrate this point:
 
 Scala
-:   @@snip [ResultTest.scala](../../../../examples/src/test/scala/example/params/ResultTest.scala) { #unique-key }
+:   @@snip [ResultExample.scala](../../../../examples/src/test/scala/example/params/ResultExample.scala) { #unique-key }
 
 Java
-:   @@snip [JResultTest.java](../../../../examples/src/test/java/example/params/JResultTest.java) { #unique-key }
+:   @@snip [JResultExample.java](../../../../examples/src/test/java/example/params/JResultExample.java) { #unique-key }
 
 ## Source Code for Examples
 
-* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/ResultTest.scala)
-* [Java Example]($github.base_url$/examples/src/test/java/example/params/JResultTest.java)
+* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/ResultExample.scala)
+* [Java Example]($github.base_url$/examples/src/test/java/example/params/JResultExample.java)

--- a/docs/src/main/params/states.md
+++ b/docs/src/main/params/states.md
@@ -13,10 +13,10 @@ The PubSub feature of the HCD provides `CurrentState` values to the PubSub subsc
 A state variable that indicates the demand or requested state.
 
 Scala
-:   @@snip [StateVariablesTest.scala](../../../../examples/src/test/scala/example/params/StateVariablesTest.scala) { #demandstate }
+:   @@snip [StateVariablesExample.scala](../../../../examples/src/test/scala/example/params/StateVariablesExample.scala) { #demandstate }
 
 Java
-:   @@snip [JStateVariablesTest.java](../../../../examples/src/test/java/example/params/JStateVariablesTest.java) { #demandstate }
+:   @@snip [JStateVariablesExample.java](../../../../examples/src/test/java/example/params/JStateVariablesExample.java) { #demandstate }
 
 
 ## CurrentState
@@ -24,20 +24,20 @@ Java
 A state variable that is published by a component that describes its internal state. Used by Assemblies to determine command completion in Command Service.
 
 Scala
-:   @@snip [StateVariablesTest.scala](../../../../examples/src/test/scala/example/params/StateVariablesTest.scala) { #currentstate }
+:   @@snip [StateVariablesExample.scala](../../../../examples/src/test/scala/example/params/StateVariablesExample.scala) { #currentstate }
 
 Java
-:   @@snip [JStateVariablesTest.java](../../../../examples/src/test/java/example/params/JStateVariablesTest.java) { #currentstate }
+:   @@snip [JStateVariablesExample.java](../../../../examples/src/test/java/example/params/JStateVariablesExample.java) { #currentstate }
 
 
 ## JSON Serialization
 State variables can be serialized to JSON. The library has provided **JsonSupport** helper class and methods to serialize DemandState and CurrentState.
 
 Scala
-:   @@snip [StateVariablesTest.scala](../../../../examples/src/test/scala/example/params/StateVariablesTest.scala) { #json-serialization }
+:   @@snip [StateVariablesExample.scala](../../../../examples/src/test/scala/example/params/StateVariablesExample.scala) { #json-serialization }
 
 Java
-:   @@snip [JStateVariablesTest.java](../../../../examples/src/test/java/example/params/JStateVariablesTest.java) { #json-serialization }
+:   @@snip [JStateVariablesExample.java](../../../../examples/src/test/java/example/params/JStateVariablesExample.java) { #json-serialization }
 
 ## Unique Key Constraint
 
@@ -55,12 +55,12 @@ parameters based on key.
 Here are some examples that illustrate this point:
 
 Scala
-:   @@snip [StateVariablesTest.scala](../../../../examples/src/test/scala/example/params/StateVariablesTest.scala) { #unique-key }
+:   @@snip [StateVariablesExample.scala](../../../../examples/src/test/scala/example/params/StateVariablesExample.scala) { #unique-key }
 
 Java
-:   @@snip [JStateVariablesTest.java](../../../../examples/src/test/java/example/params/JStateVariablesTest.java) { #unique-key }
+:   @@snip [JStateVariablesExample.java](../../../../examples/src/test/java/example/params/JStateVariablesExample.java) { #unique-key }
 
 ## Source Code for Examples
 
-* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/StateVariablesTest.scala)
-* [Java Example]($github.base_url$/examples/src/test/java/example/params/JStateVariablesTest.java)
+* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/StateVariablesExample.scala)
+* [Java Example]($github.base_url$/examples/src/test/java/example/params/JStateVariablesExample.java)

--- a/docs/src/main/params/units.md
+++ b/docs/src/main/params/units.md
@@ -104,12 +104,12 @@ The default unit for `UTCTimeKey` and `TAITimeKey` (in Scala and Java both) is `
 ## Usage Examples
 
 Scala
-:   @@snip [KeysAndParametersTest.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersTest.scala) { #units }
+:   @@snip [KeysAndParametersExample.scala](../../../../examples/src/test/scala/example/params/KeysAndParametersExample.scala) { #units }
 
 Java
-:   @@snip [JKeysAndParametersTest.java](../../../../examples/src/test/java/example/params/JKeysAndParametersTest.java) { #units }
+:   @@snip [JKeysAndParametersExample.java](../../../../examples/src/test/java/example/params/JKeysAndParametersExample.java) { #units }
 
 ## Source Code for Examples
 
-* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/KeysAndParametersTest.scala)
-* [Java Example]($github.base_url$/examples/src/test/java/example/params/JKeysAndParametersTest.java)
+* [Scala Example]($github.base_url$/examples/src/test/scala/example/params/KeysAndParametersExample.scala)
+* [Java Example]($github.base_url$/examples/src/test/java/example/params/JKeysAndParametersExample.java)

--- a/docs/src/main/services/config.md
+++ b/docs/src/main/services/config.md
@@ -65,10 +65,10 @@ and Authorization Service.  See @ref:[Admin Protected Routes](./config.md#admin-
 The `ConfigClientFactory` exposes functions to get the clientAPI and adminAPI. Both the functions require the Location Service instance which is used to resolve the `ConfigServer`.
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #create-api }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #create-api }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #create-api }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #create-api }
 
 
 @@@ note
@@ -84,20 +84,20 @@ For more details, refer to bottom section on @ref:[Admin Protected Routes](./con
 This function checks if the file exists at specified path in the repository.  It returns Future of a Boolean, whether the file exists or not.
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #exists }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #exists }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #exists }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #exists }
 
 ## getActive
 
 This function retrieves the currently active file for a given path from config service. It returns a Future of Option of ConfigData.
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #declare_string_config #getActive }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #declare_string_config #getActive }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #declare_string_config #getActive }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #declare_string_config #getActive }
 
 
 ## create
@@ -105,10 +105,10 @@ Java
 Takes input ConfigData and creates the configuration in the repository at a specified path
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #create }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #create }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #create }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #create }
 
 
 ## update
@@ -116,40 +116,40 @@ Java
 Takes input ConfigData and overwrites the configuration specified in the repository
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #update }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #update }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #update }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #update }
 
 ## delete
 
 Deletes a file located at specified path in the repository
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #delete }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #delete }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #delete }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #delete }
 
 ## getById
 
 Returns the file at a given path and matching revision Id
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #getById }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #getById }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #getById }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #getById }
 
 ## getLatest
 
 Returns the latest version of the file stored at the given path.
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #getLatest }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #getLatest }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #getLatest }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #getLatest }
 
 ## getByTime
 
@@ -159,10 +159,10 @@ Gets the file at the given path as it existed at a given time-instance. Note:
 * If time-instance is after the last change, the most recent version is returned.    
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #getByTime }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #getByTime }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #getByTime }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #getByTime }
 
 
 ## list
@@ -170,20 +170,20 @@ Java
 For a given FileType (Annex or Normal) and an optional pattern string, it will list all files whose path matches the given pattern. Some pattern examples are: "/path/hcd/*.*", "a/b/c/d.*", ".*.conf", ".*hcd.*"
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #list }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #list }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #list }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #list }
 
 ## history
 
 Returns the history of revisions of the file at the given path for a range of period specified by `from` and `to`. The size of the list can be restricted using `maxResults`.
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #history }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #history }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #history }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #history }
 
 ## Managing active versions
 
@@ -196,10 +196,10 @@ Following API functions are available to manage the active version of a config f
 * **getActiveByTime** : Returns the content of active version of the file existed at given instant 
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #active-file-mgmt }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #active-file-mgmt }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #active-file-mgmt }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #active-file-mgmt }
 
 ## getMetaData
 
@@ -211,10 +211,10 @@ Used to get metadata information about the Config Service. It includes:
 * max config file size    
 
 Scala
-:   @@snip [ConfigClientExampleTest.scala](../../../../examples/src/test/scala/example/config/ConfigClientExampleTest.scala) { #getMetadata }
+:   @@snip [ConfigClientExample.scala](../../../../examples/src/test/scala/example/config/ConfigClientExample.scala) { #getMetadata }
 
 Java
-:   @@snip [JConfigClientExampleTest.java](../../../../examples/src/test/java/example/config/JConfigClientExampleTest.java) { #getMetadata }
+:   @@snip [JConfigClientExample.java](../../../../examples/src/test/java/example/config/JConfigClientExample.java) { #getMetadata }
 
 ## Admin Protected Routes
 The following Config Server routes are `Admin Protected`. To use these routes, the user must be authenticated and authorized.
@@ -241,5 +241,5 @@ See @ref:[Configuration Service Technical Description](../technical/configuratio
 
 ## Source code for examples
 
-* [Scala Example]($github.base_url$/examples/src/test/scala/example/config/ConfigClientExampleTest.scala)
-* [Java Example]($github.base_url$/examples/src/test/java/example/config/JConfigClientExampleTest.java)
+* [Scala Example]($github.base_url$/examples/src/test/scala/example/config/ConfigClientExample.scala)
+* [Java Example]($github.base_url$/examples/src/test/java/example/config/JConfigClientExample.java)

--- a/docs/src/main/technical/params/params.md
+++ b/docs/src/main/technical/params/params.md
@@ -45,10 +45,10 @@ decoding of ADTs.
 Usage of Cbor for Event encoding and decoding is shown below:
 
 Scala
-:   @@snip [EventsTest.scala](../../../../../examples/src/test/scala/example/params/EventsTest.scala) { #cbor }
+:   @@snip [EventsExample.scala](../../../../../examples/src/test/scala/example/params/EventsExample.scala) { #cbor }
 
 Java
-:   @@snip [JEventServiceCreationExamples.java](../../../../../examples/src/test/java/example/params/JEventsTest.java) { #cbor }
+:   @@snip [JEventsExample.java](../../../../../examples/src/test/java/example/params/JEventsExample.java) { #cbor }
   
 
 ## Tooling

--- a/examples/src/main/java/example/framework/components/assembly/JAssemblyComponentHandlers.java
+++ b/examples/src/main/java/example/framework/components/assembly/JAssemblyComponentHandlers.java
@@ -210,24 +210,6 @@ public class JAssemblyComponentHandlers extends JComponentHandlers {
                 //commandResponseManager.addSubCommand(sc.runId(), subCommand2.runId());
                 //#addSubCommand
 
-                //#subscribe-to-command-response-manager
-                // subscribe to the status of original command received and publish the state when its status changes to
-                // Completed
-                /*
-                CommandResponse.SubmitResponse submitResponse = commandResponseManager
-                        .jQueryFinal(subCommand1.runId(), Timeout.create(Duration.ofSeconds(10)))
-                        .join();
-
-                if (submitResponse instanceof CommandResponse.Completed) {
-                    Key<String> stringKey = JKeyType.StringKey().make("sub-command-status");
-                    CurrentState currentState = new CurrentState(sc.source(), new StateName("testStateName"));
-                    currentStatePublisher.publish(currentState.madd(stringKey.set("complete")));
-                } else {
-                    // do something
-                }
-                */
-                //#subscribe-to-command-response-manager
-
                 //#updateSubCommand
                 // An original command is split into sub-commands and sent to a component.
                 // The result from submitting the sub-commands is used to update the CRM
@@ -243,18 +225,6 @@ public class JAssemblyComponentHandlers extends JComponentHandlers {
                         });
                 //#updateSubCommand
 
-                //#query-command-response-manager
-                // query CommandResponseManager to get the current status of Command, for example: Accepted/Completed/Invalid etc.
-                /*
-                commandResponseManager
-                        .jQuery(subCommand1.runId(), Timeout.durationToTimeout(FiniteDuration.apply(5, "seconds")))
-                        .thenAccept(commandResponse -> {
-                            // may choose to publish current state to subscribers or do other operations
-                        });
-
-                //#query-command-response-manager
-                return new CommandResponse.Completed(sc.runId());
-*/
             default:
                 log.error("Invalid command [" + sc + "] received.");
                 return new CommandResponse.Invalid(runId, new CommandIssue.UnsupportedCommandIssue(sc.commandName().toString()));   //TODO Guessed

--- a/examples/src/main/java/example/tutorial/basic/sampleassembly/JSampleAssemblyHandlers.java
+++ b/examples/src/main/java/example/tutorial/basic/sampleassembly/JSampleAssemblyHandlers.java
@@ -14,6 +14,8 @@ import csw.location.api.models.*;
 import csw.logging.api.javadsl.ILogger;
 import csw.params.commands.*;
 import csw.params.core.generics.Key;
+import csw.params.core.generics.Parameter;
+import csw.params.core.generics.ParameterSetType;
 import csw.params.core.models.Id;
 import csw.params.events.Event;
 import csw.params.events.EventKey;
@@ -24,10 +26,7 @@ import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import csw.time.core.models.UTCTime;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -187,7 +186,7 @@ public class JSampleAssemblyHandlers extends JComponentHandlers {
     CommandName cmd = setup.commandName();
     if (cmd.equals(immediateCommand)) {
       // Assembly preforms a calculation or reads state information storing in a result
-      return new Completed(runId, new Result().madd(resultKey.set(1000L)));
+      return new Completed(runId, new Result().add(resultKey.set(1000L)));
     }
     //#immediate-command
     if (cmd.equals(shortCommand)) {

--- a/examples/src/main/java/example/tutorial/basic/samplehcd/JSampleHcdHandlers.java
+++ b/examples/src/main/java/example/tutorial/basic/samplehcd/JSampleHcdHandlers.java
@@ -185,7 +185,7 @@ public class JSampleHcdHandlers extends JComponentHandlers {
                         return Behaviors.same();
                     } else if (msg instanceof Finished) {
                         Finished finished = (Finished) msg;
-                        cswCtx.commandResponseManager().updateCommand(new Completed(finished.runId, new Result().madd(resultKey.set(finished.sleepTime))));
+                        cswCtx.commandResponseManager().updateCommand(new Completed(finished.runId, new Result().add(resultKey.set(finished.sleepTime))));
                         return Behaviors.stopped();
                     } else {
                         return Behaviors.stopped();

--- a/examples/src/main/java/org/tmt/csw/sample/JSampleHandlers.java
+++ b/examples/src/main/java/org/tmt/csw/sample/JSampleHandlers.java
@@ -120,43 +120,6 @@ public class JSampleHandlers extends JComponentHandlers {
     }
     //#worker-actor
 
-    private void handle2Stage(Id runId, ICommandService hcd) {
-
-        // Construct Setup command
-        Key<Long> sleepTimeKey = JKeyType.LongKey().make("SleepTime", JUnits.millisecond);
-        Parameter<Long> sleepTimeParam = sleepTimeKey.set(5000L);
-
-        Setup setupCommand = new Setup(cswCtx.componentInfo().prefix(), new CommandName("sleep"), Optional.of(ObsId.apply("2018A-P001-O123"))).add(sleepTimeParam);
-
-        Timeout submitTimeout = new Timeout(1, TimeUnit.SECONDS);
-        Timeout commandResponseTimeout = new Timeout(10, TimeUnit.SECONDS);
-
-        // Submit command, and handle validation response. Final response is returned as a Future
-        CompletableFuture<CommandResponse.SubmitResponse> submitCommandResponseF = hcd.submitAndWait(setupCommand, submitTimeout)
-                .thenApply(commandResponse -> {
-                    if (!(commandResponse instanceof CommandResponse.Invalid || commandResponse instanceof CommandResponse.Locked)) {
-                        return commandResponse;
-                    } else {
-                        log.error("Sleep command invalid");
-                        return new CommandResponse.Error(commandResponse.runId(), "test error");
-                    }
-                }).exceptionally(ex -> new CommandResponse.Error(runId, ex.getMessage()))
-                .toCompletableFuture();
-
-
-        // Wait for final response, and log result
-        submitCommandResponseF.toCompletableFuture().thenAccept(commandResponse -> {
-            if (commandResponse instanceof CommandResponse.Completed) {
-                log.info("Command completed successfully");
-            } else if (commandResponse instanceof CommandResponse.Error) {
-                CommandResponse.Error x = (CommandResponse.Error) commandResponse;
-                log.error(() -> "Command Completed with error: " + x.message());
-            } else {
-                log.error("Command failed");
-            }
-        });
-    }
-
     //#initialize
     private Optional<IEventSubscription> maybeEventSubscription = Optional.empty();
 

--- a/examples/src/main/java/org/tmt/csw/sample/JSampleHandlersAlarm.java
+++ b/examples/src/main/java/org/tmt/csw/sample/JSampleHandlersAlarm.java
@@ -75,8 +75,7 @@ public class JSampleHandlersAlarm extends JComponentHandlers {
     private ActorRef<WorkerCommand> createWorkerActor() {
         return actorContext.spawn(
                 Behaviors.receiveMessage(msg -> {
-                    if (msg instanceof SendCommand) {
-                        SendCommand command = (SendCommand) msg;
+                    if (msg instanceof SendCommand command) {
                         log.trace("WorkerActor received SendCommand message.");
                         handle(command.hcd);
                     } else {
@@ -144,10 +143,9 @@ public class JSampleHandlersAlarm extends JComponentHandlers {
     @Override
     public void onLocationTrackingEvent(TrackingEvent trackingEvent) {
         log.debug(() -> "onLocationTrackingEvent called: " + trackingEvent.toString());
-        if (trackingEvent instanceof LocationUpdated) {
-            LocationUpdated updated = (LocationUpdated) trackingEvent;
+        if (trackingEvent instanceof LocationUpdated updated) {
             Location location = updated.location();
-            ICommandService hcd = CommandServiceFactory.jMake((AkkaLocation) (location), actorContext.getSystem());
+            ICommandService hcd = CommandServiceFactory.jMake(location, actorContext.getSystem());
             commandSender.tell(new SendCommand(hcd));
         } else if (trackingEvent instanceof LocationRemoved) {
             log.info("HCD no longer available");
@@ -161,8 +159,7 @@ public class JSampleHandlersAlarm extends JComponentHandlers {
     //#subscribe
     private void processEvent(Event event) {
         log.info("Event received: " + event.eventKey());
-        if (event instanceof SystemEvent) {
-            SystemEvent sysEvent = (SystemEvent) event;
+        if (event instanceof SystemEvent sysEvent) {
             if (event.eventKey().equals(counterEventKey)) {
                 int counter = sysEvent.parameter(hcdCounterKey).head();
                 log.info("Counter = " + counter);

--- a/examples/src/main/resources/aps_hcd_java.conf
+++ b/examples/src/main/resources/aps_hcd_java.conf
@@ -1,0 +1,4 @@
+prefix = "iris.test_component_running_long_command_java"
+componentType = hcd
+componentHandlerClassName= org.tmt.csw.sample.JCurrentStateExampleComponentHandlers
+locationServiceUsage = RegisterOnly

--- a/examples/src/main/resources/commanding_assembly.conf
+++ b/examples/src/main/resources/commanding_assembly.conf
@@ -1,0 +1,29 @@
+name = "Container_Command"
+components: [
+  {
+    prefix = "wfos.Assembly"
+    tem = WFOS
+    componentType = assembly
+    componentHandlerClassName = org.tmt.csw.sample.CurrentStateExampleComponentHandlers
+    locationServiceUsage = RegisterOnly
+    connections = [
+      {
+        prefix: "wfos.HCD"
+        componentType: hcd
+        connectionType: akka
+      }
+    ]
+  },
+  {
+    prefix = "wfos.HCD"
+    componentType = hcd
+    componentHandlerClassName = org.tmt.csw.sample.CurrentStateExampleComponentHandlers
+    locationServiceUsage = RegisterOnly
+  },
+  {
+    prefix = "tcs.Monitor_Assembly"
+    componentType = assembly
+    componentHandlerClassName = org.tmt.csw.sample.CurrentStateExampleComponentHandlers
+    locationServiceUsage = RegisterOnly
+  }
+]

--- a/examples/src/main/scala/example/auth/installed/commands/WriteCommand.scala
+++ b/examples/src/main/scala/example/auth/installed/commands/WriteCommand.scala
@@ -2,15 +2,13 @@ package example.auth.installed.commands
 
 import akka.actor.typed
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.*
+import akka.http.scaladsl.model.StatusCodes.*
 import csw.aas.installed.api.InstalledAppAuthAdapter
-
-import scala.concurrent.Await
-import scala.concurrent.duration.DurationLong
 
 // #write-command
 class WriteCommand(val installedAppAuthAdapter: InstalledAppAuthAdapter, value: String)(implicit
-    val actorSystem: typed.ActorSystem[_]
+    val actorSystem: typed.ActorSystem[?]
 ) extends AppCommand {
   override def run(): Unit = {
 
@@ -18,24 +16,22 @@ class WriteCommand(val installedAppAuthAdapter: InstalledAppAuthAdapter, value: 
       case Some(token) =>
         val bearerToken = headers.OAuth2BearerToken(token.value)
         val url         = s"http://localhost:7000/data?value=$value"
-        val response =
-          Await.result(
-            Http().singleRequest(
-              HttpRequest(
-                method = HttpMethods.POST,
-                uri = Uri(url),
-                headers = List(headers.Authorization(bearerToken))
-              )
-            ),
-            2.seconds
+        Http()
+          .singleRequest(
+            HttpRequest(
+              method = HttpMethods.POST,
+              uri = Uri(url),
+              headers = List(headers.Authorization(bearerToken))
+            )
           )
-
-        response.status match {
-          case StatusCodes.OK           => println("Success")
-          case StatusCodes.Unauthorized => println("Authentication failed")
-          case StatusCodes.Forbidden    => println("Permission denied")
-          case code                     => println(s"Unrecognised error: http status code = ${code.value}")
-        }
+          .map(response => {
+            response.status match {
+              case OK           => println("Success")
+              case Unauthorized => println("Authentication failed")
+              case Forbidden    => println("Permission denied")
+              case code         => println(s"Unrecognised error: http status code = ${code.value}")
+            }
+          })(actorSystem.executionContext)
 
       case None =>
         println("you need to login before executing this command")

--- a/examples/src/main/scala/example/tutorial/basic/samplehcd/SampleHcdHandlers.scala
+++ b/examples/src/main/scala/example/tutorial/basic/samplehcd/SampleHcdHandlers.scala
@@ -68,7 +68,7 @@ class SampleHcdHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: CswCont
   import scala.concurrent.duration._
   private def publishCounter(): Cancellable = {
     var counter = 0
-    def incrementCounterEvent() =
+    def incrementCounterEvent(): Option[SystemEvent] =
       Option {
         counter += 1
         val param: Parameter[Int] = KeyType.IntKey.make("counter").set(counter)

--- a/examples/src/main/scala/org/tmt/csw/sample/ComponentStateForCommand.scala
+++ b/examples/src/main/scala/org/tmt/csw/sample/ComponentStateForCommand.scala
@@ -1,0 +1,72 @@
+package org.tmt.csw.sample
+
+import csw.params.commands.CommandName
+import csw.params.core.generics.KeyType.{ChoiceKey, StringKey}
+import csw.params.core.generics.{GChoiceKey, Key, KeyType, Parameter}
+import csw.params.core.models.{Choice, Choices}
+import csw.params.events.EventName
+import csw.prefix.models.Prefix
+
+object ComponentStateForCommand {
+  val encoder: Key[Int]       = KeyType.IntKey.make("encoder")
+  val seqPrefix: Prefix       = Prefix("wfos.seq")
+  val filterAsmPrefix: Prefix = Prefix("wfos.blue.filter")
+//  val filterHcdPrefix       = Prefix("wfos.blue.filter.hcd")
+  val prefix: Prefix = Prefix("wfos.blue.filter")
+//  val invalidPrefix: Prefix = Prefix("wfos.blue.filter.invalid")
+
+//  val moveCmd: CommandName                   = CommandName("move")
+  val initCmd: CommandName           = CommandName("init")
+  val acceptedCmd: CommandName       = CommandName("move.accepted")
+  val longRunningCmd: CommandName    = CommandName("move.accept.result")
+  val onewayCmd: CommandName         = CommandName("move.oneway.accept")
+  val matcherCmd: CommandName        = CommandName("move.accept.matcher.success.result")
+  val matcherFailedCmd: CommandName  = CommandName("move.accept.matcher.failed.result")
+  val matcherTimeoutCmd: CommandName = CommandName("move.accept.matcher.success.timeout")
+//  val assemCurrentStateCmd: CommandName      = CommandName("assem.send.current.state")
+  val hcdCurrentStateCmd: CommandName = CommandName("hcd.send.current.state")
+  val crmAddOrUpdateCmd: CommandName  = CommandName("hcd.update.crm")
+  val immediateCmd: CommandName       = CommandName("move.immediate")
+  val immediateResCmd: CommandName    = CommandName("move.immediate.result")
+  val invalidCmd: CommandName         = CommandName("move.failure")
+//  val cancelCmd: CommandName                 = CommandName("move.cancel")
+  val failureAfterValidationCmd: CommandName = CommandName("move.accept.failure")
+
+  val longRunning: CommandName   = CommandName("move.longCmd")
+  val shortRunning: CommandName  = CommandName("move.shortCmd")
+  val mediumRunning: CommandName = CommandName("move.mediumCmd")
+
+  val longRunningCmdToHcd: CommandName        = CommandName("move.accept.toHCD")
+  val longRunningCmdToAsm: CommandName        = CommandName("move.accept.toAsm")
+  val longRunningCmdToAsmInvalid: CommandName = CommandName("move.accept.toAsmError")
+  val longRunningCmdToAsmComp: CommandName    = CommandName("move.accept.toAsmWithCompleter")
+  val longRunningCmdToAsmCActor: CommandName  = CommandName("move.accept.toAsmWithCompleterActor")
+  val cmdWithBigParameter: CommandName        = CommandName("complex.command.parameters")
+  val shorterHcdCmd: CommandName              = CommandName("move.accept.shorterInHcd")
+  val shorterHcdErrorCmd: CommandName         = CommandName("move.accept.shorterErrorInHcd")
+
+  val longRunningCmdCompleted: Choice  = Choice("Long Running Cmd Completed")
+  val longRunningCurrentStatus: Choice = Choice("Long Running Cmd Completed")
+  val shortCmdCompleted: Choice        = Choice("Short Running Sub Cmd Completed")
+  val mediumCmdCompleted: Choice       = Choice("Medium Running Sub Cmd Completed")
+  val longCmdCompleted: Choice         = Choice("Long Running Sub Cmd Completed")
+  val onlineChoice: Choice             = Choice("Online")
+  val shutdownChoice: Choice           = Choice("Shutdown")
+  val initChoice: Choice               = Choice("Initialize")
+  val offlineChoice: Choice            = Choice("Offline")
+  val choices: Choices = Choices.fromChoices(
+    shortCmdCompleted,
+    mediumCmdCompleted,
+    longCmdCompleted,
+    longRunningCmdCompleted,
+    longRunningCurrentStatus,
+    onlineChoice,
+    shutdownChoice,
+    initChoice,
+    offlineChoice
+  )
+  val choiceKey: GChoiceKey = ChoiceKey.make("choiceKey", choices)
+
+  val diagnosticDataEventName: EventName     = EventName("diagnostic-data")
+  val diagnosticModeParam: Parameter[String] = StringKey.make("diagnostic-data").set("diagnostic-publish")
+}

--- a/examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala
+++ b/examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala
@@ -1,41 +1,47 @@
-package csw.common.components.command
+package org.tmt.csw.sample
 
+import akka.actor.Cancellable
 import akka.actor.typed.scaladsl.ActorContext
+import akka.stream.ThrottleMode
+import akka.stream.scaladsl.{Sink, Source}
 import akka.util.Timeout
 import csw.command.api.scaladsl.CommandService
 import csw.command.client.CommandResponseManager.{OverallFailure, OverallSuccess}
 import csw.command.client.CommandServiceFactory
 import csw.command.client.messages.TopLevelActorMessage
-import csw.common.components.command.CommandComponentState._
 import csw.framework.models.CswContext
 import csw.framework.scaladsl.ComponentHandlers
 import csw.location.api.models.ComponentType.HCD
 import csw.location.api.models.Connection.AkkaConnection
 import csw.location.api.models.{ComponentId, TrackingEvent}
+import csw.location.api.scaladsl.LocationService
 import csw.logging.api.scaladsl.Logger
+import csw.params.commands.*
 import csw.params.commands.CommandIssue.OtherIssue
-import csw.params.commands.CommandResponse._
-import csw.params.commands._
+import csw.params.commands.CommandResponse.*
+import csw.params.core.generics.KeyType
 import csw.params.core.models.Id
 import csw.params.core.states.{CurrentState, StateName}
+import csw.params.events.SystemEvent
 import csw.prefix.models.{Prefix, Subsystem}
 import csw.time.core.models.UTCTime
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext}
 import scala.util.{Failure, Success}
 
-class CommandAssemblyHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: CswContext)
+class CurrentStateExampleComponentHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: CswContext)
     extends ComponentHandlers(ctx, cswCtx) {
 
-  import cswCtx._
+  import ComponentStateForCommand.*
+  import cswCtx.*
 
   private val log: Logger                   = loggerFactory.getLogger(ctx)
   private implicit val ec: ExecutionContext = ctx.executionContext
+  private implicit val actorSystem          = ctx.system
   private implicit val timeout: Timeout     = 15.seconds
-
-  private val filterHCDConnection = AkkaConnection(ComponentId(Prefix(Subsystem.WFOS, "FilterHCD"), HCD))
-  // val locationService: LocationService = HttpLocationServiceFactory.makeLocalClient(ctx.system, clientMat)
+  private val filterHCDConnection           = AkkaConnection(ComponentId(Prefix(Subsystem.CSW, "samplehcd"), HCD))
+  val locationService: LocationService      = cswCtx.locationService
 
   private val filterHCDLocation    = Await.result(locationService.resolve(filterHCDConnection, 5.seconds), 5.seconds)
   var hcdComponent: CommandService = CommandServiceFactory.make(filterHCDLocation.get)(ctx.system)
@@ -45,12 +51,12 @@ class CommandAssemblyHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
   private val shortRunningError = Setup(seqPrefix, shorterHcdErrorCmd, None)
 
   override def initialize(): Unit = {
-    // DEOPSCSW-153: Accessibility of logging service to other CSW components
     log.info("Initializing Assembly Component TLA")
-
+    // #currentStatePublisher
     Thread.sleep(100)
     // Publish the CurrentState using parameter set created using a sample Choice parameter
     currentStatePublisher.publish(CurrentState(filterAsmPrefix, StateName("testStateName"), Set(choiceKey.set(initChoice))))
+    // #currentStatePublisher
   }
 
   override def onGoOffline(): Unit =
@@ -61,8 +67,11 @@ class CommandAssemblyHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
 
   def validateCommand(runId: Id, command: ControlCommand): ValidateCommandResponse = {
     command.commandName match {
+      case `longRunning`   => Accepted(runId)
+      case `mediumRunning` => Accepted(runId)
+      case `shortRunning`  => Accepted(runId)
       case `immediateCmd` | `longRunningCmd` | `longRunningCmdToAsm` | `longRunningCmdToAsmComp` | `longRunningCmdToAsmInvalid` |
-          `longRunningCmdToAsmCActor` | `cmdWithBigParameter` =>
+          `longRunningCmdToAsmCActor` | `cmdWithBigParameter` | `hcdCurrentStateCmd` | `matcherCmd` =>
         Accepted(runId)
       case `invalidCmd` =>
         Invalid(runId, OtherIssue("Invalid"))
@@ -76,23 +85,47 @@ class CommandAssemblyHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
   }
 
   override def onOneway(runId: Id, controlCommand: ControlCommand): Unit = {
-    processCommand(runId, controlCommand)
+    processCommandWithMatcher(controlCommand)
   }
-
+  private def processCommandWithMatcher(controlCommand: ControlCommand): Unit =
+    controlCommand.commandName match {
+      case `hcdCurrentStateCmd` =>
+        processCurrentStateOneway(controlCommand)
+      case `matcherTimeoutCmd` => Thread.sleep(1000)
+      case `matcherFailedCmd` =>
+        Source(1 to 10)
+          .map(i =>
+            currentStatePublisher.publish(
+              CurrentState(controlCommand.source, StateName("testStateName"), Set(KeyType.IntKey.make("encoder").set(i * 1)))
+            )
+          )
+          .throttle(1, 100.millis, 1, ThrottleMode.Shaping)
+          .runWith(Sink.ignore)
+      case _ =>
+        Source(1 to 10)
+          .map(i =>
+            currentStatePublisher.publish(
+              CurrentState(controlCommand.source, StateName("testStateName"), Set(KeyType.IntKey.make("encoder").set(i * 10)))
+            )
+          )
+          .throttle(1, 100.millis, 1, ThrottleMode.Shaping)
+          .runWith(Sink.ignore)
+    }
   def processCommand(runId: Id, command: ControlCommand): SubmitResponse =
     command.commandName match {
       case `immediateCmd` =>
         Completed(runId)
-
+      // #longRunning
       case `longRunningCmd` =>
         // A local assembly command that takes some time returning Started
         timeServiceScheduler.scheduleOnce(UTCTime(UTCTime.now().value.plusSeconds(2))) {
           // After time expires, send final update
-          commandResponseManager.updateCommand(Completed(runId))
+          commandResponseManager.updateCommand(Completed(runId, Result(encoder.set(20))))
         }
         // Starts long-runing and returns started
         Started(runId)
-
+      // #longRunning
+      // #queryFinalAll
       case `longRunningCmdToAsm` =>
         hcdComponent.submitAndWait(longRunning).foreach {
           case _: Completed =>
@@ -113,7 +146,7 @@ class CommandAssemblyHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
         commandResponseManager.queryFinalAll(long, shorter).onComplete {
           case Success(response) =>
             response match {
-              case OverallSuccess(r) =>
+              case OverallSuccess(_) =>
                 commandResponseManager.updateCommand(Completed(runId))
               case OverallFailure(responses) =>
                 commandResponseManager.updateCommand(Error(runId, s"$responses"))
@@ -122,7 +155,7 @@ class CommandAssemblyHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
             commandResponseManager.updateCommand(Error(runId, ex.toString))
         }
         Started(runId)
-
+      // #queryFinalAll
       case `longRunningCmdToAsmInvalid` =>
         val long    = hcdComponent.submitAndWait(longRunning)
         val shorter = hcdComponent.submitAndWait(shortRunningError)
@@ -152,9 +185,32 @@ class CommandAssemblyHandlers(ctx: ActorContext[TopLevelActorMessage], cswCtx: C
     Thread.sleep(500)
   }
 
+  private def processCurrentStateOneway(controlCommand: ControlCommand): Unit = {
+    val currentState = CurrentState(prefix, StateName("HCDState"), controlCommand.paramSet)
+    cswCtx.currentStatePublisher.publish(currentState)
+  }
+
   override def onLocationTrackingEvent(trackingEvent: TrackingEvent): Unit = {}
 
-  override def onDiagnosticMode(startTime: UTCTime, hint: String): Unit = {}
+  // #onDiagnostic-mode
+  // While dealing with mutable state, make sure you create a worker actor to avoid concurrency issues
+  // For functionality demonstration, we have simply used a mutable variable without worker actor
+  var diagModeCancellable: Option[Cancellable] = None
 
-  override def onOperationsMode(): Unit = {}
+  override def onDiagnosticMode(startTime: UTCTime, hint: String): Unit = {
+    hint match {
+      case "engineering" =>
+        val event = SystemEvent(prefix, diagnosticDataEventName).add(diagnosticModeParam)
+        diagModeCancellable.foreach(_.cancel()) // cancel previous diagnostic publishing
+        diagModeCancellable = Some(eventService.defaultPublisher.publish(Some(event), startTime, 200.millis))
+      case _ =>
+    }
+  }
+  // #onDiagnostic-mode
+
+  // #onOperations-mode
+  override def onOperationsMode(): Unit = {
+    diagModeCancellable.foreach(_.cancel())
+  }
+  // #onOperations-mode
 }

--- a/examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala
+++ b/examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala
@@ -1,6 +1,7 @@
 package org.tmt.csw.sample
 
 import akka.actor.Cancellable
+import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.ActorContext
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.{Sink, Source}
@@ -36,15 +37,15 @@ class CurrentStateExampleComponentHandlers(ctx: ActorContext[TopLevelActorMessag
   import ComponentStateForCommand.*
   import cswCtx.*
 
-  private val log: Logger                   = loggerFactory.getLogger(ctx)
-  private implicit val ec: ExecutionContext = ctx.executionContext
-  private implicit val actorSystem          = ctx.system
-  private implicit val timeout: Timeout     = 15.seconds
-  private val filterHCDConnection           = AkkaConnection(ComponentId(Prefix(Subsystem.CSW, "samplehcd"), HCD))
-  val locationService: LocationService      = cswCtx.locationService
+  private val log: Logger                                = loggerFactory.getLogger(ctx)
+  private implicit val ec: ExecutionContext              = ctx.executionContext
+  private implicit val actorSystem: ActorSystem[Nothing] = ctx.system
+  private implicit val timeout: Timeout                  = 15.seconds
+  private val filterHCDConnection                        = AkkaConnection(ComponentId(Prefix(Subsystem.CSW, "samplehcd"), HCD))
+  val locationService: LocationService                   = cswCtx.locationService
 
   private val filterHCDLocation    = Await.result(locationService.resolve(filterHCDConnection, 5.seconds), 5.seconds)
-  var hcdComponent: CommandService = CommandServiceFactory.make(filterHCDLocation.get)(ctx.system)
+  val hcdComponent: CommandService = CommandServiceFactory.make(filterHCDLocation.get)(ctx.system)
 
   private val longRunning       = Setup(seqPrefix, longRunningCmdToHcd, None)
   private val shortRunning      = Setup(seqPrefix, shorterHcdCmd, None)

--- a/examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala
+++ b/examples/src/main/scala/org/tmt/csw/sample/CurrentStateExampleComponentHandlers.scala
@@ -53,7 +53,6 @@ class CurrentStateExampleComponentHandlers(ctx: ActorContext[TopLevelActorMessag
   override def initialize(): Unit = {
     log.info("Initializing Assembly Component TLA")
     // #currentStatePublisher
-    Thread.sleep(100)
     // Publish the CurrentState using parameter set created using a sample Choice parameter
     currentStatePublisher.publish(CurrentState(filterAsmPrefix, StateName("testStateName"), Set(choiceKey.set(initChoice))))
     // #currentStatePublisher

--- a/examples/src/main/scala/org/tmt/csw/sample/SampleComponentState.scala
+++ b/examples/src/main/scala/org/tmt/csw/sample/SampleComponentState.scala
@@ -1,0 +1,79 @@
+package org.tmt.csw.sample
+
+import csw.alarm.models.AlarmSeverity
+import csw.alarm.models.AlarmSeverity.Warning
+import csw.alarm.models.Key.AlarmKey
+import csw.location.api.models
+import csw.location.api.models.Connection.{HttpConnection, TcpConnection}
+import csw.location.api.models.{ComponentId, ComponentType}
+import csw.params.commands.CommandName
+import csw.params.core.generics.KeyType.{ChoiceKey, StringKey}
+import csw.params.core.generics.{GChoiceKey, Parameter}
+import csw.params.core.models.{Choice, Choices}
+import csw.params.core.states.StateName
+import csw.params.events.EventName
+import csw.prefix.models.Subsystem.NFIRAOS
+import csw.prefix.models.{Prefix, Subsystem}
+
+object SampleComponentState {
+  val restartChoice             = Choice("Restart")
+  val onlineChoice              = Choice("Online")
+  val domainChoice              = Choice("Domain")
+  val shutdownChoice            = Choice("Shutdown")
+  val setupConfigChoice         = Choice("SetupConfig")
+  val observeConfigChoice       = Choice("ObserveConfig")
+  val commandValidationChoice   = Choice("CommandValidation")
+  val submitCommandChoice       = Choice("SubmitCommand")
+  val oneWayCommandChoice       = Choice("OneWayCommand")
+  val initChoice                = Choice("Initialize")
+  val offlineChoice             = Choice("Offline")
+  val akkaLocationUpdatedChoice = Choice("LocationUpdated")
+  val akkaLocationRemovedChoice = Choice("LocationRemoved")
+  val httpLocationUpdatedChoice = Choice("HttpLocationUpdated")
+  val httpLocationRemovedChoice = Choice("HttpLocationRemoved")
+  val tcpLocationUpdatedChoice  = Choice("TcpLocationUpdated")
+  val tcpLocationRemovedChoice  = Choice("TcpLocationRemoved")
+  val eventReceivedChoice       = Choice("EventReceived")
+  val prefix                    = Prefix("wfos.prog.cloudcover")
+  val successPrefix             = Prefix("wfos.prog.cloudcover.success")
+  val failedPrefix              = Prefix("wfos.prog.cloudcover.failure")
+
+  val setSeverityCommand          = CommandName("alarm.setSeverity.success")
+  val testAlarmKey                = AlarmKey(Prefix(NFIRAOS, "trombone"), "tromboneAxisHighLimitAlarm")
+  val testSeverity: AlarmSeverity = Warning
+
+  val diagnosticDataEventName                = EventName("diagnostic-data")
+  val diagnosticModeParam: Parameter[String] = StringKey.make("diagnostic-data").set("diagnostic-publish")
+
+  val choices: Choices =
+    Choices.fromChoices(
+      restartChoice,
+      onlineChoice,
+      domainChoice,
+      shutdownChoice,
+      setupConfigChoice,
+      observeConfigChoice,
+      commandValidationChoice,
+      submitCommandChoice,
+      oneWayCommandChoice,
+      initChoice,
+      offlineChoice,
+      akkaLocationUpdatedChoice,
+      akkaLocationRemovedChoice,
+      httpLocationUpdatedChoice,
+      httpLocationRemovedChoice,
+      tcpLocationUpdatedChoice,
+      tcpLocationRemovedChoice,
+      eventReceivedChoice
+    )
+  val choiceKey: GChoiceKey = ChoiceKey.make("choiceKey", choices)
+  val httpConnection: HttpConnection = HttpConnection(
+    ComponentId(Prefix(Subsystem.CSW, "exampleHTTPService"), ComponentType.Service)
+  )
+  val tcpConnection: TcpConnection = TcpConnection(
+    models.ComponentId(Prefix(Subsystem.CSW, "exampleTcpService"), ComponentType.Service)
+  )
+
+  // States
+  val timeServiceSchedulerState = StateName("timeServiceSchedulerState")
+}

--- a/examples/src/test/java/example/command/JCommandExample.java
+++ b/examples/src/test/java/example/command/JCommandExample.java
@@ -1,4 +1,4 @@
-package csw.framework.command;
+package example.command;
 
 import akka.actor.testkit.typed.javadsl.TestInbox;
 import akka.actor.testkit.typed.javadsl.TestProbe;
@@ -10,25 +10,19 @@ import csw.command.api.DemandMatcher;
 import csw.command.api.StateMatcher;
 import csw.command.api.javadsl.ICommandService;
 import csw.command.client.CommandServiceFactory;
-import csw.command.client.extensions.AkkaLocationExt;
-import csw.command.client.messages.SupervisorLockMessage;
-import csw.command.client.models.framework.LockingResponse;
-import csw.common.components.framework.SampleComponentState;
 import csw.framework.internal.wiring.FrameworkWiring;
 import csw.framework.internal.wiring.Standalone;
 import csw.location.api.javadsl.ILocationService;
 import csw.location.api.javadsl.JComponentType;
-import csw.location.client.ActorSystemFactory;
-import csw.location.client.javadsl.JHttpLocationServiceFactory;
 import csw.location.api.models.AkkaLocation;
 import csw.location.api.models.ComponentId;
 import csw.location.api.models.Connection.AkkaConnection;
+import csw.location.client.ActorSystemFactory;
+import csw.location.client.javadsl.JHttpLocationServiceFactory;
 import csw.location.server.http.JHTTPLocationService;
-import csw.params.commands.CommandIssue;
-import csw.params.commands.CommandResponse;
-import csw.params.commands.CommandResponse.*;
-import csw.params.commands.Result;
-import csw.params.commands.Setup;
+import csw.params.commands.*;
+import csw.params.commands.CommandResponse.Completed;
+import csw.params.commands.CommandResponse.SubmitResponse;
 import csw.params.core.generics.Key;
 import csw.params.core.generics.Parameter;
 import csw.params.core.models.Id;
@@ -37,8 +31,8 @@ import csw.params.core.states.DemandState;
 import csw.params.core.states.StateName;
 import csw.params.javadsl.JKeyType;
 import csw.params.javadsl.JUnits;
-import csw.prefix.models.Prefix;
 import csw.prefix.javadsl.JSubsystem;
+import csw.prefix.models.Prefix;
 import io.lettuce.core.RedisClient;
 import msocket.api.Subscription;
 import org.junit.AfterClass;
@@ -58,26 +52,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static csw.common.components.command.ComponentStateForCommand.*;
+import static csw.params.commands.CommandResponse.*;
+import static org.tmt.csw.sample.ComponentStateForCommand.*;
 
-// DEOPSCSW-212: Send oneway command
-// DEOPSCSW-217: Execute RPC like commands
-// DEOPSCSW-224: Inter component command sending
-// DEOPSCSW-225: Allow components to receive commands
-// DEOPSCSW-227: Distribute commands to multiple destinations
-// DEOPSCSW-228: Assist Components with command completion
-// DEOPSCSW-234: CCS accessibility to all CSW component builders
-// DEOPSCSW-317: Use state values of HCD to determine command completion
-// DEOPSCSW-321: AkkaLocation provides wrapper for ActorRef[ComponentMessage]
-@SuppressWarnings("unchecked")
-public class JCommandIntegrationTest extends JUnitSuite {
+public class JCommandExample extends JUnitSuite {
     private static final ActorSystem<SpawnProtocol.Command> hcdActorSystem = ActorSystemFactory.remote(SpawnProtocol.create(), "test");
 
     private static JHTTPLocationService jHttpLocationService;
     private static ILocationService locationService;
     private static ICommandService hcdCmdService;
     private static AkkaLocation hcdLocation;
-    private final Timeout timeout = new Timeout(5, TimeUnit.SECONDS);
+    private final Timeout timeout = new Timeout(20, TimeUnit.SECONDS);
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -96,12 +81,13 @@ public class JCommandIntegrationTest extends JUnitSuite {
         jHttpLocationService.afterAll();
     }
 
+
     private static AkkaLocation getLocation() throws Exception {
         RedisClient redisClient = null;
         FrameworkWiring wiring = FrameworkWiring.make(hcdActorSystem, redisClient);
         Await.result(Standalone.spawn(ConfigFactory.load("aps_hcd_java.conf"), wiring), new FiniteDuration(5, TimeUnit.SECONDS));
 
-        AkkaConnection akkaConnection = new AkkaConnection(new ComponentId(Prefix.apply(JSubsystem.IRIS, "Test_Component_Running_Long_Command_Java"), JComponentType.HCD));
+        AkkaConnection akkaConnection = new AkkaConnection(new ComponentId(Prefix.apply(JSubsystem.IRIS, "test_component_running_long_command_java"), JComponentType.HCD));
         CompletableFuture<Optional<AkkaLocation>> eventualLocation = locationService.resolve(akkaConnection, java.time.Duration.ofSeconds(5));
         Optional<AkkaLocation> maybeLocation = eventualLocation.get();
         Assert.assertTrue(maybeLocation.isPresent());
@@ -110,12 +96,13 @@ public class JCommandIntegrationTest extends JUnitSuite {
     }
 
     @Test
-    public void testCommandExecutionBetweenComponents__DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225_DEOPSCSW_229_CSW_174() throws Exception {
-
+    public void testCommandExecutionBetweenComponents() throws Exception {
+//
         Key<Integer> encoder = JKeyType.IntKey().make("encoder", JUnits.encoder);
         Parameter<Integer> encoderValue = encoder.set(22, 23);
         Setup immediateCmd = new Setup(prefix(), immediateCmd(), Optional.empty()).add(encoderValue);
 
+        //#immediate-response
         CompletableFuture<SubmitResponse> immediateCommandF =
                 hcdCmdService.submitAndWait(immediateCmd, timeout).thenApply(
                         response -> {
@@ -127,6 +114,7 @@ public class JCommandIntegrationTest extends JUnitSuite {
                             return response;
                         }
                 );
+        //#immediate-response
         Assert.assertTrue(immediateCommandF.get() instanceof Completed);
         Completed completed = (Completed) immediateCommandF.get();
         Assert.assertFalse(completed.result().nonEmpty());
@@ -135,19 +123,19 @@ public class JCommandIntegrationTest extends JUnitSuite {
         Setup imdResCommand = new Setup(prefix(), immediateResCmd(), Optional.empty()).add(encoderValue);
 
         CompletableFuture<SubmitResponse> imdResCmdResponseCompletableFuture = hcdCmdService.submitAndWait(imdResCommand, timeout);
-        CommandResponse.SubmitResponse actualImdCmdResponse = imdResCmdResponseCompletableFuture.get();
+        SubmitResponse actualImdCmdResponse = imdResCmdResponseCompletableFuture.get();
         Assert.assertTrue(actualImdCmdResponse instanceof Completed);
         completed = (Completed) actualImdCmdResponse;
         Assert.assertTrue(completed.result().nonEmpty());
         Assert.assertEquals(imdResCommand.paramSet(), completed.result().paramSet());
 
+        //#invalidCmd
         Setup invalidSetup = new Setup(prefix(), invalidCmd(), Optional.empty()).add(encoderValue);
         CompletableFuture<SubmitResponse> invalidCommandF =
                 hcdCmdService.submitAndWait(invalidSetup, timeout).thenApply(
                         response -> {
-                            if (response instanceof Invalid) {
+                            if (response instanceof Invalid invalid) {
                                 // Cast the response to get the issue
-                                CommandResponse.Invalid invalid = (Invalid) response;
                                 assert (invalid.issue().reason().contains("failure"));
                             } else {
                                 // Just do something to make the test fail
@@ -157,28 +145,31 @@ public class JCommandIntegrationTest extends JUnitSuite {
                         }
                 );
 
-        Assert.assertTrue(invalidCommandF.get() instanceof CommandResponse.Invalid);
-        CommandResponse.Invalid invalidResponse = (CommandResponse.Invalid) invalidCommandF.get();
+        //#invalidCmd
+        Assert.assertTrue(invalidCommandF.get() instanceof Invalid);
+        Invalid invalidResponse = (Invalid) invalidCommandF.get();
         Assert.assertEquals(new CommandIssue.OtherIssue("Testing: Received failure, will return Invalid."), invalidResponse.issue());
 
+        //#invalidSubmitCmd
         CompletableFuture<SubmitResponse> invalidSubmitCommandF =
                 hcdCmdService.submit(invalidSetup).thenApply(
                         response -> {
                             if (response instanceof Started) {
                                 //do something with completed result
-                            } else if (response instanceof Invalid) {
+                            } else if (response instanceof Invalid invalid) {
                                 // Cast the response to get the issue
-                                Invalid invalid = (Invalid) response;
                                 assert (invalid.issue().reason().contains("failure"));
                             }
                             return response;
                         }
                 );
-        Assert.assertTrue(invalidSubmitCommandF.get() instanceof CommandResponse.Invalid);
-        invalidResponse = (CommandResponse.Invalid) invalidSubmitCommandF.get();
+        //#invalidSubmitCmd
+        Assert.assertTrue(invalidSubmitCommandF.get() instanceof Invalid);
+        invalidResponse = (Invalid) invalidSubmitCommandF.get();
         Assert.assertEquals(new CommandIssue.OtherIssue("Testing: Received failure, will return Invalid."), invalidResponse.issue());
 
         // long running command which does not use matcher
+        //#longRunning
         Setup longRunningSetup = new Setup(prefix(), longRunningCmd(), Optional.empty()).add(encoderValue);
         CompletableFuture<Optional<Integer>> longRunningResultF =
                 hcdCmdService.submitAndWait(longRunningSetup, timeout)
@@ -193,11 +184,13 @@ public class JCommandIntegrationTest extends JUnitSuite {
                                 return CompletableFuture.completedFuture(Optional.empty());
                             }
                         });
+        //#longRunning
         Optional<Integer> expectedCmdResponse = Optional.of(20);
         Optional<Integer> actualCmdResponse = longRunningResultF.get();
         Assert.assertEquals(expectedCmdResponse, actualCmdResponse);
 
-        CompletableFuture<CommandResponse.SubmitResponse> longRunningCommandResultF =
+        //#queryLongRunning
+        CompletableFuture<SubmitResponse> longRunningCommandResultF =
                 hcdCmdService.submitAndWait(longRunningSetup, timeout);
 
         // do some work before querying for the result of above command as needed
@@ -225,7 +218,9 @@ public class JCommandIntegrationTest extends JUnitSuite {
                     }
                 });
         Assert.assertEquals(Optional.of(20), intF.get());
+        //#queryLongRunning
 
+        //#submitAndQueryFinal
         CompletableFuture<SubmitResponse> longRunningResultF2 = hcdCmdService.submit(longRunningSetup)
                 .thenCompose(response -> {
                     if (response instanceof Started) {
@@ -238,13 +233,27 @@ public class JCommandIntegrationTest extends JUnitSuite {
                     }
                 });
 
+        //#submitAndQueryFinal
 
+        //#submitAndQuery
         CompletableFuture<SubmitResponse> longRunningSubmitResultF3 = hcdCmdService.submit(longRunningSetup);
 
         // do some work before querying for the result of above command as needed
         CompletableFuture<SubmitResponse> queryResponseF3 =
                 hcdCmdService.query(longRunningSubmitResultF3.get().runId());
+        queryResponseF3.thenAccept(r -> {
+            if (r instanceof Started) {
+                // happy case - no action needed
+                // Do some other work
+            } else {
+                // log.error. This indicates that the command probably failed to start.
+            }
+        });
+        //#submitAndQuery
+//        CompletableFuture<SubmitResponse> queryResponseF3 =
+//                hcdCmdService.query(longRunningSubmitResultF3.get().runId());
 
+        //#queryFinal
         longRunningCommandResultF = hcdCmdService.submitAndWait(longRunningSetup, timeout);
         sresponse = longRunningCommandResultF.get();
 
@@ -262,10 +271,14 @@ public class JCommandIntegrationTest extends JUnitSuite {
                     }
                 });
         Assert.assertEquals(Optional.of(20), int3F.get());
+        //#queryFinal
 
+        //#query
         CompletableFuture<SubmitResponse> queryResponseF2 = hcdCmdService.query(sresponse.runId());
         Assert.assertTrue(queryResponseF2.get() instanceof Completed);
+        //#query
 
+        //#oneway
         Setup onewaySetup = new Setup(prefix(), onewayCmd(), Optional.empty()).add(encoderValue);
         CompletableFuture<Void> onewayF = hcdCmdService
                 .oneway(onewaySetup)
@@ -276,9 +289,11 @@ public class JCommandIntegrationTest extends JUnitSuite {
                         // Ignore anything other than invalid
                     }
                 });
+        //#oneway
         // just wait for command completion so that it will not impact other results
         onewayF.get();
 
+        //#validate
         CompletableFuture<Boolean> validateCommandF =
                 hcdCmdService.validate(immediateCmd)
                         .thenApply(
@@ -296,7 +311,9 @@ public class JCommandIntegrationTest extends JUnitSuite {
                                 }
                         );
         Assert.assertTrue(validateCommandF.get());
+        //#validate
 
+        //#submitAll
         Setup submitAllSetup1 = new Setup(prefix(), immediateCmd(), Optional.empty()).add(encoderValue);
         Setup submitAllSetup2 = new Setup(prefix(), longRunningCmd(), Optional.empty()).add(encoderValue);
         Setup submitAllSetup3 = new Setup(prefix(), invalidCmd(), Optional.empty()).add(encoderValue);
@@ -309,7 +326,9 @@ public class JCommandIntegrationTest extends JUnitSuite {
         Assert.assertTrue(submitAllResponse.get(0) instanceof Completed);
         Assert.assertTrue(submitAllResponse.get(1) instanceof Completed);
         Assert.assertTrue(submitAllResponse.get(2) instanceof Invalid);
+        //#submitAll
 
+        //#submitAllInvalid
         CompletableFuture<List<SubmitResponse>> submitAllF2 = hcdCmdService
                 .submitAllAndWait(
                         List.of(submitAllSetup1, submitAllSetup3, submitAllSetup2),
@@ -320,20 +339,10 @@ public class JCommandIntegrationTest extends JUnitSuite {
         Assert.assertEquals(submitAllResponse2.size(), 2);
         Assert.assertTrue(submitAllResponse2.get(0) instanceof Completed);
         Assert.assertTrue(submitAllResponse2.get(1) instanceof Invalid);
+        //#submitAllInvalid
 
-        // Test Test
-        Setup qfAllSetup1 = new Setup(prefix(), shortRunning(), Optional.empty());
-        Setup qfAllSetup2 = new Setup(prefix(), mediumRunning(), Optional.empty());
-        Setup qfAllSetup3 = new Setup(prefix(), longRunning(), Optional.empty());
-        CompletableFuture<SubmitResponse> shortSubmit = hcdCmdService.submitAndWait(qfAllSetup1, timeout);
-        CompletableFuture<SubmitResponse> mediumSubmit = hcdCmdService.submitAndWait(qfAllSetup2, timeout);
-        CompletableFuture<SubmitResponse> longSubmit = hcdCmdService.submitAndWait(qfAllSetup3, timeout);
-
-        
-
-
-
-        // Subscriber code
+        //#subscribeCurrentState
+        // Subscriber cod
         int expectedEncoderValue = 234;
         Setup currStateSetup = new Setup(prefix(), hcdCurrentStateCmd(), Optional.empty()).add(encoder.set(expectedEncoderValue));
         // Setup a callback response to CurrentState - use AtomicInteger to capture final value
@@ -354,9 +363,11 @@ public class JCommandIntegrationTest extends JUnitSuite {
 
         // Unsubscribe from CurrentState
         subscription.cancel();
+        //#subscribeCurrentState
 
         // DEOPSCSW-229: Provide matchers infrastructure for comparison
         // long running command which uses matcher
+        //#matcher
         Parameter<Integer> param = JKeyType.IntKey().make("encoder", JUnits.encoder).set(100);
         Setup setupWithMatcher = new Setup(prefix(), matcherCmd(), Optional.empty()).add(param);
 
@@ -366,123 +377,60 @@ public class JCommandIntegrationTest extends JUnitSuite {
         // Submit command as a oneway and if the command is successfully validated,
         // check for matching of demand state against current state
         CompletableFuture<MatchingResponse> matchResponseF = hcdCmdService.onewayAndMatch(setupWithMatcher, demandMatcher);
-
         MatchingResponse actualResponse = matchResponseF.get();
         Completed expectedResponse = new Completed(actualResponse.runId());
-        Assert.assertEquals(expectedResponse, actualResponse);     // Not a great test for now
+        Assert.assertEquals(expectedResponse, actualResponse);            // Not a great test for now
+        //#matcher
 
+        //#onewayAndMatch
         // create a DemandMatcher which specifies the desired state to be matched.
         StateMatcher stateMatcher = new DemandMatcher(new DemandState(prefix(), new StateName("testStateName")).add(param), false, timeout);
 
         CompletableFuture<MatchingResponse> matchedCommandResponseF =
                 hcdCmdService.onewayAndMatch(setupWithMatcher, stateMatcher);
 
-        CommandResponse.MatchingResponse mresponse = matchedCommandResponseF.get();
-        Assert.assertTrue(mresponse instanceof CommandResponse.MatchingResponse.Completed);
+        //#onewayAndMatch
+        MatchingResponse mresponse = matchedCommandResponseF.get();
+        Assert.assertTrue(mresponse instanceof Completed);
     }
 
+
     @Test
-    public void testSupervisorLock__DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225() throws ExecutionException, InterruptedException {
-        // Lock scenarios
-        TestProbe<LockingResponse> probe = TestProbe.create(hcdActorSystem);
-        FiniteDuration duration = new FiniteDuration(5, TimeUnit.SECONDS);
-
-        // Lock component
-        AkkaLocationExt.RichAkkaLocation(hcdLocation).componentRef(hcdActorSystem).tell(new SupervisorLockMessage.Lock(prefix(), probe.ref(), duration));
-        probe.expectMessage(LockingResponse.lockAcquired());
-
-        Key<Integer> intKey2 = JKeyType.IntKey().make("encoder", JUnits.encoder);
-        Parameter<Integer> intParameter2 = intKey2.set(22, 23);
-
-        // Send command to locked component and verify that it is not allowed
-        Setup imdSetupCommand = new Setup(invalidPrefix(), immediateCmd(), Optional.empty()).add(intParameter2);
-        CompletableFuture<SubmitResponse> lockedCmdResCompletableFuture = hcdCmdService.submitAndWait(imdSetupCommand, timeout);
-        SubmitResponse actualLockedCmdResponse = lockedCmdResCompletableFuture.get();
-
-        Assert.assertTrue(actualLockedCmdResponse instanceof CommandResponse.Locked);
-
-        // Unlock component
-        AkkaLocationExt.RichAkkaLocation(hcdLocation).componentRef(hcdActorSystem).tell(new SupervisorLockMessage.Unlock(prefix(), probe.ref()));
-        probe.expectMessage(LockingResponse.lockReleased());
-
-        CompletableFuture<CommandResponse.SubmitResponse> cmdAfterUnlockResCompletableFuture = hcdCmdService.submit(imdSetupCommand);
-        CommandResponse.SubmitResponse actualCmdResponseAfterUnlock = cmdAfterUnlockResCompletableFuture.get();
-        Assert.assertTrue(actualCmdResponseAfterUnlock instanceof CommandResponse.Completed);
-    }
-
-    // DEOPSCSW-208: Report failure on Configuration Completion command
-    @Test
-    public void testCommandFailure__DEOPSCSW_208_DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225() throws ExecutionException, InterruptedException {
+    public void testCommandFailure() throws InterruptedException, ExecutionException {
         // using single submitAndSubscribe API
         Key<Integer> intKey1 = JKeyType.IntKey().make("encoder", JUnits.encoder);
         Parameter<Integer> intParameter1 = intKey1.set(22, 23);
         Setup failureResCommand = new Setup(prefix(), failureAfterValidationCmd(), Optional.empty()).add(intParameter1);
 
+        //#submitAndWait
         CompletableFuture<SubmitResponse> finalResponseCompletableFuture = hcdCmdService.submitAndWait(failureResCommand, timeout);
         SubmitResponse actualValidationResponse = finalResponseCompletableFuture.get();
+        //#submitAndWait
 
         Assert.assertTrue(actualValidationResponse instanceof CommandResponse.Error);
-
-        // using separate submit and subscribe API
-        CompletableFuture<SubmitResponse> validationResponse = hcdCmdService.submit(failureResCommand);
-        Id runId = validationResponse.get().runId();
-        CompletableFuture<SubmitResponse> finalResponse = hcdCmdService.queryFinal(runId, timeout);
-        Assert.assertTrue(finalResponse.get() instanceof CommandResponse.Error);  // This should fail but I guess not typed by compiler
     }
 
-    @Test
-    public void testSubmitAll__DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225() throws ExecutionException, InterruptedException {
-        Parameter<Integer> encoderParam = JKeyType.IntKey().make("encoder", JUnits.encoder).set(22, 23);
-
-        Setup setupHcd1 = new Setup(prefix(), shortRunning(), Optional.empty()).add(encoderParam);
-        Setup setupHcd2 = new Setup(prefix(), mediumRunning(), Optional.empty()).add(encoderParam);
-
-        CompletableFuture<List<SubmitResponse>> finalCommandResponse = hcdCmdService
-                .submitAllAndWait(
-                        List.of(setupHcd1, setupHcd2),
-                        timeout
-                );
-
-        List<CommandResponse.SubmitResponse> actualSubmitResponses = finalCommandResponse.get();
-        Assert.assertEquals(2, actualSubmitResponses.size());
-        // List<CommandResponse.Completed> expectedResponses = List.of(new CommandResponse.Completed(setupHcd1.runId()), new CommandResponse.Completed(setupHcd2.runId()));
-        //Assert.assertEquals(expectedResponses, actualSubmitResponses);
-    }
 
     @Test
-    public void testSubscribeCurrentState__DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225_DEOPSCSW_372() throws InterruptedException {
+    public void testSubscribeCurrentState() {
         Key<Integer> intKey1 = JKeyType.IntKey().make("encoder", JUnits.encoder);
         Parameter<Integer> intParameter1 = intKey1.set(22, 23);
         Setup setup = new Setup(prefix(), acceptedCmd(), Optional.empty()).add(intParameter1);
 
         TestProbe<CurrentState> probe = TestProbe.create(hcdActorSystem);
 
-        // DEOPSCSW-372: Provide an API for PubSubActor that hides actor based interaction
+        //#subscribeCurrentState
         // subscribe to the current state of an assembly component and use a callback which forwards each received
         // element to a test probe actor
         Subscription subscription = hcdCmdService.subscribeCurrentState(currentState -> probe.ref().tell(currentState));
+        //#subscribeCurrentState
 
         hcdCmdService.submitAndWait(setup, timeout);
 
-        CurrentState currentState = new CurrentState(SampleComponentState.prefix(), new StateName("testStateName"));
-        CurrentState expectedValidationCurrentState = currentState.add(SampleComponentState.choiceKey().set(SampleComponentState.commandValidationChoice()));
-        CurrentState expectedSubmitCurrentState = currentState.add(SampleComponentState.choiceKey().set(SampleComponentState.submitCommandChoice()));
-        CurrentState expectedSetupCurrentState = new CurrentState(SampleComponentState.prefix(), new StateName("testStateSetup")).madd(SampleComponentState.choiceKey().set(SampleComponentState.setupConfigChoice()), intParameter1);
-
-        probe.expectMessage(expectedValidationCurrentState);
-        probe.expectMessage(expectedSubmitCurrentState);
-        probe.expectMessage(expectedSetupCurrentState);
-
-        // unsubscribe and verify no messages received by probe
-        subscription.cancel();
-        Thread.sleep(1000);
-
-        hcdCmdService.submitAndWait(setup, timeout);
-        probe.expectNoMessage(java.time.Duration.ofMillis(20));
     }
 
     @Test
-    public void testSubscribeOnlyCurrentState__DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225_DEOPSCSW_434() throws InterruptedException {
+    public void testSubscribeOnlyCurrentState() throws InterruptedException {
         Key<Integer> intKey1 = JKeyType.IntKey().make("encoder", JUnits.encoder);
         Parameter<Integer> intParameter1 = intKey1.set(22, 23);
         Setup setup = new Setup(prefix(), acceptedCmd(), Optional.empty()).add(intParameter1);
@@ -490,45 +438,14 @@ public class JCommandIntegrationTest extends JUnitSuite {
         TestInbox<CurrentState> inbox = TestInbox.create();
         Thread.sleep(1000);
 
-        // DEOPSCSW-434: Provide an API for PubSubActor that hides actor based interaction
+
+        //#subscribeOnlyCurrentState
         // subscribe to the current state of an assembly component and use a callback which forwards each received
         // element to a test probe actor
         Subscription subscription = hcdCmdService.subscribeCurrentState(Set.of(StateName.apply("testStateSetup")), currentState -> inbox.getRef().tell(currentState));
+        //#subscribeOnlyCurrentState
 
         hcdCmdService.submitAndWait(setup, timeout);
 
-        CurrentState currentState = new CurrentState(SampleComponentState.prefix(), new StateName("testStateName"));
-        CurrentState expectedValidationCurrentState = currentState.add(SampleComponentState.choiceKey().set(SampleComponentState.commandValidationChoice()));
-        CurrentState expectedSubmitCurrentState = currentState.add(SampleComponentState.choiceKey().set(SampleComponentState.submitCommandChoice()));
-        CurrentState expectedSetupCurrentState = new CurrentState(SampleComponentState.prefix(), new StateName("testStateSetup")).madd(SampleComponentState.choiceKey().set(SampleComponentState.setupConfigChoice()), intParameter1);
-
-        Thread.sleep(1000);
-        List<CurrentState> receivedStates = inbox.getAllReceived();
-
-        Assert.assertFalse(receivedStates.contains(expectedValidationCurrentState));
-        Assert.assertFalse(receivedStates.contains(expectedSubmitCurrentState));
-        Assert.assertTrue(receivedStates.contains(expectedSetupCurrentState));
-
-        subscription.cancel();
     }
-
-    @Test
-    public void testCRMUsageForCompletion__DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225() throws Exception {
-        Setup crmAddSetup = new Setup(prefix(), crmAddOrUpdateCmd(), Optional.empty());
-        CompletableFuture<CommandResponse.SubmitResponse> addOrUpdateCommandF =
-                hcdCmdService.submitAndWait(crmAddSetup, timeout);
-        Assert.assertTrue(addOrUpdateCommandF.get() instanceof CommandResponse.Completed);
-    }
-
-    @Test
-    // Note this is exactly the same as the previous test
-    public void testCRMUsageForSubCommands__DEOPSCSW_224_DEOPSCSW_317_DEOPSCSW_212_DEOPSCSW_227_DEOPSCSW_228_DEOPSCSW_217_DEOPSCSW_321_DEOPSCSW_234_DEOPSCSW_225() throws Exception {
-        Setup crmAddSetup = new Setup(prefix(), crmAddOrUpdateCmd(), Optional.empty());
-        CompletableFuture<CommandResponse.SubmitResponse> addOrUpdateCommandF =
-                hcdCmdService.submitAndWait(crmAddSetup, timeout);
-        //CommandResponse.Completed expectedResponse = new CommandResponse.Completed(crmAddSetup.runId());
-        //Assert.assertEquals(expectedResponse, addOrUpdateCommandF.get());
-        Assert.assertTrue(addOrUpdateCommandF.get() instanceof CommandResponse.Completed);
-    }
-
 }

--- a/examples/src/test/java/example/command/JCommandServiceExample.java
+++ b/examples/src/test/java/example/command/JCommandServiceExample.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static csw.params.commands.CommandResponse.*;
 import static org.tmt.csw.sample.ComponentStateForCommand.*;
 
-public class JCommandExample extends JUnitSuite {
+public class JCommandServiceExample extends JUnitSuite {
     private static final ActorSystem<SpawnProtocol.Command> hcdActorSystem = ActorSystemFactory.remote(SpawnProtocol.create(), "test");
 
     private static JHTTPLocationService jHttpLocationService;

--- a/examples/src/test/java/example/config/JConfigClientExample.java
+++ b/examples/src/test/java/example/config/JConfigClientExample.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-public class JConfigClientExampleTest extends JUnitSuite {
+public class JConfigClientExample extends JUnitSuite {
 
     // DEOPSCSW-592: Create csw testkit for component writers
     @ClassRule

--- a/examples/src/test/java/example/params/JCommandsExample.java
+++ b/examples/src/test/java/example/params/JCommandsExample.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
-public class JCommandsTest extends JUnitSuite {
+public class JCommandsExample extends JUnitSuite {
     //#obsid
     final ObsId obsId = ObsId.apply("2020A-001-123");
     //#obsid

--- a/examples/src/test/java/example/params/JEventsExample.java
+++ b/examples/src/test/java/example/params/JEventsExample.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 //DEOPSCSW-331: Event Service Accessible to all CSW component builders
 @SuppressWarnings("unchecked")
-public class JEventsTest extends JUnitSuite {
+public class JEventsExample extends JUnitSuite {
 
     @Test
     public void showUsageOfEventTime__DEOPSCSW_331() {

--- a/examples/src/test/java/example/params/JKeysAndParametersExample.java
+++ b/examples/src/test/java/example/params/JKeysAndParametersExample.java
@@ -18,7 +18,7 @@ import static csw.params.core.models.Coords.*;
 import static csw.params.core.models.JCoords.*;
 
 @SuppressWarnings({"unused", "RedundantCast", "unchecked", "ArraysAsListWithZeroOrOneArgument"})
-public class JKeysAndParametersTest extends JUnitSuite {
+public class JKeysAndParametersExample extends JUnitSuite {
 
     @Test
     public void showUsageOfPrimitiveTypes() {

--- a/examples/src/test/java/example/params/JResultExample.java
+++ b/examples/src/test/java/example/params/JResultExample.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
-public class JResultTest extends JUnitSuite {
+public class JResultExample extends JUnitSuite {
 
     //#runid
     Id runId = Id.apply();

--- a/examples/src/test/java/example/params/JStateVariablesExample.java
+++ b/examples/src/test/java/example/params/JStateVariablesExample.java
@@ -28,7 +28,7 @@ import static csw.params.javadsl.JUnits.NoUnits;
 import static csw.params.javadsl.JUnits.meter;
 
 @SuppressWarnings("unchecked")
-public class JStateVariablesTest extends JUnitSuite {
+public class JStateVariablesExample extends JUnitSuite {
 
     @Test
     public void showUsageOfDemandState() {

--- a/examples/src/test/java/example/testkit/JTestKitsExample.java
+++ b/examples/src/test/java/example/testkit/JTestKitsExample.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
-public class JTestKitsExampleTest extends JUnitSuite {
+public class JTestKitsExample extends JUnitSuite {
 
     //#framework-testkit
     private static final FrameworkTestKit frameworkTestKit = FrameworkTestKit.create();

--- a/examples/src/test/java/example/testkit/JUnitAlarmTestKitExample.java
+++ b/examples/src/test/java/example/testkit/JUnitAlarmTestKitExample.java
@@ -15,7 +15,7 @@ import org.scalatestplus.junit.JUnitSuite;
 import java.util.Arrays;
 
 //#junit-alarm-testkit
-class JUnitAlarmTestKitExampleTest extends JUnitSuite {
+class JUnitAlarmTestKitExample extends JUnitSuite {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/examples/src/test/java/example/testkit/JUnitDatabaseTestKitExample.java
+++ b/examples/src/test/java/example/testkit/JUnitDatabaseTestKitExample.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeoutException;
 
 //#CSW-161
 //#junit-database-testkit
-class JUnitDatabaseTestKitExampleTest extends JUnitSuite {
+class JUnitDatabaseTestKitExample extends JUnitSuite {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/examples/src/test/java/example/testkit/JUnitIntegrationExample.java
+++ b/examples/src/test/java/example/testkit/JUnitIntegrationExample.java
@@ -11,7 +11,7 @@ import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 
-public class JUnitIntegrationExampleTest extends JUnitSuite {
+public class JUnitIntegrationExample extends JUnitSuite {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/examples/src/test/scala/example/command/CommandExample.scala
+++ b/examples/src/test/scala/example/command/CommandExample.scala
@@ -1,0 +1,329 @@
+package example.command
+
+import akka.actor.typed.{ActorSystem, SpawnProtocol}
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import csw.command.api.{DemandMatcher, StateMatcher}
+import csw.command.client.CommandServiceFactory
+import csw.location.api.models
+import csw.location.api.models.Connection.AkkaConnection
+import csw.location.api.models.{AkkaLocation, ComponentType}
+import csw.location.api.scaladsl.LocationService
+import csw.logging.client.scaladsl.LoggerFactory
+import csw.params.commands.*
+import csw.params.commands.CommandIssue.IdNotAvailableIssue
+import csw.params.commands.CommandResponse.*
+import csw.params.core.generics.Parameter
+import csw.params.core.models.{Id, ObsId}
+import csw.params.core.states.{CurrentState, DemandState, StateName}
+import csw.prefix.models.Subsystem.CSW
+import csw.prefix.models.{Prefix, Subsystem}
+import csw.testkit.scaladsl.CSWService.EventServer
+import csw.testkit.scaladsl.ScalaTestFrameworkTestKit
+import org.scalatest.concurrent.Eventually
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.async.Async.*
+import scala.concurrent.duration.DurationDouble
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class CommandExample()
+    extends ScalaTestFrameworkTestKit(EventServer)
+    with AnyFunSuiteLike
+    with MockitoSugar
+    with Matchers
+    with Eventually {
+
+  import org.tmt.csw.sample.ComponentStateForCommand.*
+
+  private implicit val timeout: Timeout                                = 5.seconds
+  private implicit val typedSystem: ActorSystem[SpawnProtocol.Command] = frameworkTestKit.actorSystem
+  private implicit val ec: ExecutionContext                            = typedSystem.executionContext
+  implicit private val patience: PatienceConfig                        = PatienceConfig(5.seconds, 100.millis)
+  val locationService: LocationService                                 = frameworkTestKit.locationService
+  private val loggerFactory                                            = new LoggerFactory(Prefix(CSW, "command.example"))
+  val log                                                              = loggerFactory.getLogger
+  test(s"$prefix sender of command should receive appropriate responses") {
+    implicit val timeout: Timeout     = 5.seconds
+    implicit val ec: ExecutionContext = typedSystem.executionContext
+
+    val obsId = Some(ObsId("2020A-001-123"))
+
+    // spawn single assembly running in Standalone mode in jvm-2
+    val sampleHcdConf = ConfigFactory.load("SampleHcdStandalone.conf")
+    spawnStandalone(sampleHcdConf)
+    val sampleHcdLocF =
+      locationService.resolve(
+        AkkaConnection(models.ComponentId(Prefix(Subsystem.CSW, "samplehcd"), ComponentType.HCD)),
+        15.seconds
+      )
+    val sampleHcdLocation: AkkaLocation = Await.result(sampleHcdLocF, 10.seconds).get
+    val assemblyConf                    = ConfigFactory.load("commanding_assembly.conf")
+    spawnContainer(assemblyConf)
+    // resolve assembly running in jvm-3 and send setup command expecting immediate command completion response
+    // #resolve-hcd-and-create-commandservice
+    val assemblyLocF =
+      locationService.resolve(
+        AkkaConnection(models.ComponentId(Prefix(Subsystem.WFOS, "Assembly"), ComponentType.Assembly)),
+        15.seconds
+      )
+    val assemblyLocation: AkkaLocation = Await.result(assemblyLocF, 10.seconds).get
+    val assemblyCmdService             = CommandServiceFactory.make(assemblyLocation)
+    // #resolve-hcd-and-create-commandservice
+    // resolve assembly running in jvm-3 and send setup command expecting immediate command completion response
+    val hcdLocF =
+      locationService.resolve(AkkaConnection(models.ComponentId(Prefix(Subsystem.WFOS, "HCD"), ComponentType.HCD)), 15.seconds)
+    val hcdLocation: AkkaLocation = Await.result(hcdLocF, 15.seconds).get
+    val hcdCmdService             = CommandServiceFactory.make(hcdLocation)
+
+    // #invalidCmd
+    val invalidSetup    = Setup(prefix, invalidCmd, obsId)
+    val invalidCommandF = assemblyCmdService.submitAndWait(invalidSetup)
+    val resultF: Future[Unit] = async {
+      await(invalidCommandF) match {
+        case Completed(_, _) =>
+        // Do Completed thing
+        case Invalid(_, _) =>
+        // issue shouldBe a[Invalid]
+        case other =>
+          // Unexpected result
+          log.error(s"Some other response: $other")
+      }
+    }
+    // #invalidCmd
+    Await.result(invalidCommandF, 5.seconds) shouldBe a[Invalid]
+
+    // just to remove the warning of unused and the nullary method. Cannot add @nowarn as it is a snippet for docs.
+    Await.result(resultF, 5.seconds)
+
+    // short running command
+    // #immediate-response
+    val immediateSetup = Setup(prefix, immediateCmd, obsId)
+    val immediateCommandF: Future[SubmitResponse] = async {
+      await(assemblyCmdService.submitAndWait(immediateSetup)) match {
+        case response: Completed =>
+          // do something with completed result
+          response
+        case otherResponse =>
+          // do something with other response which is not expected
+          otherResponse
+      }
+    }
+    // #immediate-response
+    Await.result(immediateCommandF, timeout.duration) shouldBe a[Completed]
+
+    // #longRunning
+    val longRunningSetup = Setup(prefix, longRunningCmd, obsId)
+
+    val longRunningResultF: Future[Option[Int]] = async {
+      await(assemblyCmdService.submitAndWait(longRunningSetup)) match {
+        case Completed(_, result) =>
+          result.nonEmpty shouldBe true
+          Some(result(encoder).head)
+
+        case otherResponse =>
+          // log a message?
+          None
+      }
+    }
+    // #longRunning
+    val longRunningResult = Await.result(longRunningResultF, timeout.duration)
+    longRunningResult shouldBe Some(20)
+
+    // long running command which does not use matcher
+    var longRunningRunId: Id = Id("blah") // Is updated below for use in later test
+
+    // #queryLongRunning
+    val longRunningQueryResultF: Future[Option[Int]] = async {
+      // The following val is set so we can do query and work and complete later
+      val longRunningF = assemblyCmdService.submit(longRunningSetup)
+      // This is used in a later test
+      longRunningRunId = await(longRunningF).runId
+
+      await(assemblyCmdService.query(longRunningRunId)) match {
+        case Started(runId) =>
+          runId shouldEqual longRunningRunId
+        // happy case - no action needed
+        // Do some other work
+        case a =>
+        // log.error. This indicates that the command probably failed to start.
+      }
+
+      // Now wait for completion and result
+      await(assemblyCmdService.queryFinal(longRunningRunId)) match {
+        case Completed(_, result) =>
+          Some(result(encoder).head)
+
+        case otherResponse =>
+          // log a message?
+          None
+      }
+    }
+    // #queryLongRunning
+    Await.result(longRunningQueryResultF, timeout.duration) shouldBe Some(20)
+
+    // This test shows DEOPSCSW-623 because submit is issued without future and queryFinal works
+    // #queryFinal
+    val queryFinalF: Future[Option[Int]] = async {
+      // The following submit is made without saving the Future!
+      val runId = await(assemblyCmdService.submit(longRunningSetup)).runId
+
+      // Use queryFinal and runId to wait for completion and result
+      await(assemblyCmdService.queryFinal(runId)) match {
+        case Completed(_, result) =>
+          Some(result(encoder).head)
+
+        case otherResponse =>
+          // log a message?
+          None
+      }
+    }
+    // #queryFinal
+    Await.result(queryFinalF, timeout.duration) shouldBe Some(20)
+
+    // #queryFinalWithSubmitAndWait
+    val encoderValue: Future[Option[Int]] = async {
+      // The following submit is made without saving the Future!
+      val runId = await(assemblyCmdService.submitAndWait(longRunningSetup)).runId
+
+      // Use queryFinal and runId to wait for completion and result
+      await(assemblyCmdService.queryFinal(runId)) match {
+        case Completed(_, result) =>
+          Some(result(encoder).head)
+
+        case otherResponse =>
+          // log a message?
+          None
+      }
+    }
+    // #queryFinalWithSubmitAndWait
+    Await.result(encoderValue, timeout.duration) shouldBe Some(20)
+
+    // #oneway
+    // `onewayCmd` is a sample to demonstrate oneway without any actions
+    val onewaySetup = Setup(prefix, onewayCmd, obsId)
+    // Don't care about the futures from async
+    val oneWayF: Future[Unit] = async {
+      await(assemblyCmdService.oneway(onewaySetup)) match {
+        case invalid: Invalid =>
+        // Log an error here
+        case _ =>
+        // Ignore anything other than invalid
+      }
+    }
+    Await.ready(oneWayF, timeout.duration)
+    // #oneway
+
+    // #validate
+    val validateCommandF: Future[Boolean] = async {
+      await(assemblyCmdService.validate(immediateSetup)) match {
+        case _: Accepted       => true
+        case Invalid(_, issue) =>
+          // do something with other response which is not expected
+          log.error(s"Command failed to validate with issue: $issue")
+          false
+        case _: Locked => false
+      }
+    }
+    // #validate
+    Await.result(validateCommandF, timeout.duration) shouldBe true
+
+    // test CommandNotAvailable after timeout of 1 seconds
+    Await.result(assemblyCmdService.query(Id("blah")), 2.seconds) shouldEqual
+    Invalid(Id("blah"), IdNotAvailableIssue(Id("blah").id))
+
+    // #query
+    // Check on a command that was completed in the past
+    val queryValue = Await.result(assemblyCmdService.query(longRunningRunId), timeout.duration)
+    // #query
+    queryValue shouldBe a[Completed]
+
+    val submitAllSetup1       = Setup(prefix, immediateCmd, obsId)
+    val submitAllSetup2       = Setup(prefix, longRunningCmd, obsId)
+    val submitAllinvalidSetup = Setup(prefix, invalidCmd, obsId)
+
+    // #submitAll
+    val submitAllF: Future[List[SubmitResponse]] = async {
+      await(assemblyCmdService.submitAllAndWait(List(submitAllSetup1, submitAllSetup2, submitAllinvalidSetup)))
+    }
+    val submitAllResponse = Await.result(submitAllF, timeout.duration)
+    // #submitAll
+    submitAllResponse.length shouldBe 3
+    submitAllResponse(0) shouldBe a[Completed]
+    submitAllResponse(1) shouldBe a[Completed]
+    submitAllResponse(2) shouldBe a[Invalid]
+
+    // #submitAllInvalid
+    val submitAllF2: Future[List[SubmitResponse]] = async {
+      await(assemblyCmdService.submitAllAndWait(List(submitAllSetup1, submitAllinvalidSetup, submitAllSetup2)))
+    }
+    val submitAllResponse2 = Await.result(submitAllF2, timeout.duration)
+    // #submitAllInvalid
+    submitAllResponse2.length shouldBe 2
+    submitAllResponse2(0) shouldBe a[Completed]
+    submitAllResponse2(1) shouldBe a[Invalid]
+
+    // #subscribeCurrentState
+    // Subscriber code
+    val expectedEncoderValue = 234
+    val currStateSetup       = Setup(prefix, hcdCurrentStateCmd, obsId).add(encoder.set(expectedEncoderValue))
+    // Setup a callback response to CurrentState
+    var cstate: CurrentState = CurrentState(prefix, StateName("no cstate"), Set.empty)
+    val subscription         = hcdCmdService.subscribeCurrentState(cs => cstate = cs)
+    // Send a oneway to the HCD that will cause it to publish a CurrentState with the encoder value
+    // in the command parameter "encoder". Callback will store value into cstate.
+    hcdCmdService.oneway(currStateSetup)
+
+    // Eventually current state callback will get invoked when hcd publish its state
+    // Test to see if value was received
+    eventually(cstate(encoder).head shouldBe expectedEncoderValue)
+
+    // Unsubscribe to CurrentState
+    subscription.cancel()
+    // #subscribeCurrentState
+
+    // long running command which uses matcher
+    // #matcher
+    val param: Parameter[Int] = encoder.set(100)
+    val setupWithMatcher      = Setup(prefix, matcherCmd, obsId)
+
+    // create a StateMatcher which specifies the desired algorithm and state to be matched.
+    val demandMatcher: StateMatcher =
+      DemandMatcher(DemandState(prefix, StateName("testStateName")).add(param), withUnits = false, timeout)
+
+    // Submit command as a oneway and if the command is successfully validated,
+    // check for matching of demand state against current state
+    val matchResponseF: Future[MatchingResponse] = assemblyCmdService.onewayAndMatch(setupWithMatcher, demandMatcher)
+
+    val commandResponse = Await.result(matchResponseF, timeout.duration)
+    // #matcher
+    commandResponse shouldBe a[Completed]
+
+    // #onewayAndMatch
+    val onewayMatchF: Future[SubmitResponse with MatchingResponse] = async {
+      await(assemblyCmdService.onewayAndMatch(setupWithMatcher, demandMatcher)) match {
+        case i: Invalid =>
+          // Command was not accepted
+          log.error(s"Oneway match was not accepted: ${i.issue}")
+          i
+        case c: Completed =>
+          // Do some completed work
+          c
+        case e: Error =>
+          // Match failed and timedout generating an error - log a message
+          log.error(s"Oeway match produced an error: ${e.message}")
+          e
+        case l: Locked =>
+          // Destination component was locked, log a message
+          log.error(s"Destination component was locked")
+          l
+      }
+    }
+    // #onewayAndMatch
+    Await.result(onewayMatchF, timeout.duration) shouldBe a[Completed]
+
+  }
+
+}

--- a/examples/src/test/scala/example/command/CommandServiceExample.scala
+++ b/examples/src/test/scala/example/command/CommandServiceExample.scala
@@ -30,7 +30,7 @@ import scala.async.Async.*
 import scala.concurrent.duration.DurationDouble
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class CommandExample()
+class CommandServiceExample
     extends ScalaTestFrameworkTestKit(EventServer)
     with AnyFunSuiteLike
     with MockitoSugar
@@ -60,7 +60,7 @@ class CommandExample()
         AkkaConnection(models.ComponentId(Prefix(Subsystem.CSW, "samplehcd"), ComponentType.HCD)),
         15.seconds
       )
-    //wait for sampleHcd to be up & running before spawning assembly, as it requires sample hcd to be running.
+    // wait for sampleHcd to be up & running before spawning assembly, as it requires sample hcd to be running.
     Await.result(sampleHcdLocF, 10.seconds).get
     val assemblyConf = ConfigFactory.load("commanding_assembly.conf")
     spawnContainer(assemblyConf)

--- a/examples/src/test/scala/example/config/ConfigClientExample.scala
+++ b/examples/src/test/scala/example/config/ConfigClientExample.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{Await, Future}
 
 // DEOPSCSW-89: Examples of  Configuration Service usage in Java and Scala
 // DEOPSCSW-592: Create csw testkit for component writers
-class ConfigClientExampleTest
+class ConfigClientExample
     extends ScalaTestFrameworkTestKit(ConfigServer)
     with AnyFunSuiteLike
     with BeforeAndAfterEach

--- a/examples/src/test/scala/example/config/ConfigClientExample.scala
+++ b/examples/src/test/scala/example/config/ConfigClientExample.scala
@@ -59,10 +59,12 @@ class ConfigClientExample
 
       // check if file exists with config service
       val exists: Boolean = await(clientApi.exists(filePath))
+      // exists returns true/false
+      // #exists
+
       exists shouldBe true
     }
     Await.result(doneF, 5.seconds)
-    // #exists
   }
 
   test("getActive | DEOPSCSW-89, DEOPSCSW-592") {
@@ -74,10 +76,11 @@ class ConfigClientExample
       await(adminApi.create(filePath, ConfigData.fromString(defaultStrConf), annex = false, "First commit"))
 
       val activeFile: Option[ConfigData] = await(clientApi.getActive(filePath))
+      // activeFile.get returns content of defaultStrConf
+      // #getActive
       await(activeFile.get.toStringF(actorSystem)) shouldBe defaultStrConf
     }
     Await.result(doneF, 5.seconds)
-    // #getActive
   }
 
   test("create-update-delete | DEOPSCSW-89, DEOPSCSW-592") {
@@ -116,6 +119,10 @@ class ConfigClientExample
         // store the config, at a specified path as a binary file in annex store
         val id3: ConfigId =
           await(adminApi.create(Paths.get("/hcd/trombone/debug.bin"), config3, annex = true, "new file from vendor"))
+        // id1 returns ConfigId(1)
+        // id2 returns ConfigId(3)
+        // id3 returns ConfigId(5)
+        // #create
 
         // CAUTION: for demo example setup these IDs are returned. Don't assume them in production setup.
         id1 shouldEqual ConfigId(1)
@@ -123,7 +130,6 @@ class ConfigClientExample
         id3 shouldEqual ConfigId(5)
       }
     Await.result(futC, 2.seconds)
-    // #create
 
     // #update
     val futU = async {
@@ -132,22 +138,24 @@ class ConfigClientExample
         adminApi
           .update(destPath, ConfigData.fromString(defaultStrConf), comment = "debug statements")
       )
-
+      // newId returns ConfigId(7)
+      // #update
       // validate the returned id
       newId shouldEqual ConfigId(7)
     }
     Await.result(futU, 2.seconds)
-    // #update
 
     // #delete
     val futD = async {
       val unwantedFilePath = Paths.get("/hcd/trombone/debug.bin")
       await(adminApi.delete(unwantedFilePath, "no longer needed"))
       // validates the file is deleted
-      await(adminApi.getLatest(unwantedFilePath)) shouldBe None
+      val maybeConfigData = await(adminApi.getLatest(unwantedFilePath))
+      // maybeConfigData returns None
+      // #delete
+      maybeConfigData shouldBe None
     }
     Await.result(futD, 2.seconds)
-    // #delete
   }
 
   test("getById | DEOPSCSW-89, DEOPSCSW-592") {
@@ -160,10 +168,11 @@ class ConfigClientExample
 
       // validate
       val actualData = await(adminApi.getById(filePath, id)).get
+      // actualData returns defaultStrConf
+      // #getById
       await(actualData.toStringF(actorSystem)) shouldBe defaultStrConf
     }
     Await.result(doneF, 2.seconds)
-    // #getById
   }
 
   test("getLatest | DEOPSCSW-89, DEOPSCSW-592") {
@@ -180,10 +189,11 @@ class ConfigClientExample
       // get the latest file
       val newConfigData = await(adminApi.getLatest(filePath)).get
       // validate
+      // newConfigData returns newContent
+      // #getLatest
       await(newConfigData.toStringF(actorSystem)) shouldBe newContent
     }
     Await.result(assertionF, 2.seconds)
-    // #getLatest
   }
 
   test("getByTime | DEOPSCSW-89, DEOPSCSW-592") {
@@ -199,13 +209,16 @@ class ConfigClientExample
       await(adminApi.update(filePath, ConfigData.fromString(newContent), "changed!!"))
 
       val initialData: ConfigData = await(adminApi.getByTime(filePath, tInitial)).get
-      await(initialData.toStringF(actorSystem)) shouldBe defaultStrConf
+      // initialData returns defaultStrConf
 
       val latestData = await(adminApi.getByTime(filePath, Instant.now())).get
+      // latestData returns defaultStrConf
+      // #getByTime
+      await(initialData.toStringF(actorSystem)) shouldBe defaultStrConf
       await(latestData.toStringF(actorSystem)) shouldBe newContent
     }
     Await.result(assertionF, 2.seconds)
-    // #getByTime
+
   }
 
   test("list | DEOPSCSW-89, DEOPSCSW-592") {
@@ -226,39 +239,49 @@ class ConfigClientExample
           adminApi.create(path, ConfigData.fromString(defaultStrConf), Annex == fileType, "initial commit")
         )
       }
+      // #list
       Await.result(createF, 2.seconds)
+    // #list
     }
 
-    val assertionF = async {
-      // retrieve list of all files; for demonstration purpose show validate return values
-      await(adminApi.list()).map(info => info.path).toSet shouldBe paths.map { case (path, _) =>
+    val responsesF = async {
+      // retrieve list of all files;
+      val allFilesF = await(adminApi.list()).map(info => info.path).toSet
+
+      // retrieve list of files based on type;
+      val allAnnexFilesF  = await(adminApi.list(Some(Annex))).map(info => info.path).toSet
+      val allNormalFilesF = await(adminApi.list(Some(FileType.Normal))).map(info => info.path).toSet
+
+      // retrieve list using pattern;
+      val confFilesByPatternF = await(adminApi.list(None, Some(".*.conf"))).map(info => info.path.toString).toSet
+
+      // retrieve list using pattern and file type;
+      val allNormalConfFilesF = await(adminApi.list(Some(FileType.Normal), Some(".*.conf"))).map(info => info.path.toString).toSet
+
+      val testConfF          = await(adminApi.list(Some(FileType.Normal), Some("test.*"))).map(info => info.path.toString).toSet
+      val allAnnexConfFilesF = await(adminApi.list(Some(Annex), Some("a/c.*"))).map(info => info.path.toString).toSet
+      // #list
+
+      // for correctness, validate return values
+      allFilesF shouldBe paths.map { case (path, _) =>
         path
       }.toSet
-
-      // retrieve list of files based on type; for demonstration purpose validate return values
-      await(adminApi.list(Some(Annex))).map(info => info.path).toSet shouldBe paths.collect {
-        case (path, fileType) if fileType == Annex => path
-      }.toSet
-      await(adminApi.list(Some(FileType.Normal))).map(info => info.path).toSet shouldBe paths.collect {
+      allNormalConfFilesF shouldBe Set("a/b/c/hcd/hcd.conf", "testing/test.conf")
+      allAnnexConfFilesF shouldBe Set("a/c/trombone.conf")
+      allNormalFilesF shouldBe paths.collect {
         case (path, fileType) if fileType == FileType.Normal => path
       }.toSet
-
-      // retrieve list using pattern; for demonstration purpose validate return values
-      await(adminApi.list(None, Some(".*.conf"))).map(info => info.path.toString).toSet shouldBe Set(
+      confFilesByPatternF shouldBe Set(
         "a/b/c/hcd/hcd.conf",
         "a/c/trombone.conf",
         "testing/test.conf"
       )
-      // retrieve list using pattern and file type; for demonstration purpose validate return values
-      await(adminApi.list(Some(FileType.Normal), Some(".*.conf"))).map(info => info.path.toString).toSet shouldBe
-      Set("a/b/c/hcd/hcd.conf", "testing/test.conf")
-      await(adminApi.list(Some(Annex), Some("a/c.*"))).map(info => info.path.toString).toSet shouldBe
-      Set("a/c/trombone.conf")
-      await(adminApi.list(Some(FileType.Normal), Some("test.*"))).map(info => info.path.toString).toSet shouldBe
-      Set("testing/test.conf")
+      allAnnexFilesF shouldBe paths.collect {
+        case (path, fileType) if fileType == Annex => path
+      }.toSet
+      testConfF shouldBe Set("testing/test.conf")
     }
-    Await.result(assertionF, 2.seconds)
-    // #list
+    Await.result(responsesF, 2.seconds)
   }
 
   test("history | DEOPSCSW-89, DEOPSCSW-592") {
@@ -275,17 +298,20 @@ class ConfigClientExample
 
       // full file history
       val fullHistory = await(adminApi.history(filePath))
-      fullHistory.map(_.id) shouldBe List(id2, id1, id0)
-      fullHistory.map(_.comment) shouldBe List("third commit", "second commit", "first commit")
 
       // drop initial revision and take only update revisions
-      await(adminApi.history(filePath, tBeginUpdate, tEndUpdate)).map(_.id) shouldBe List(id2, id1)
+      val revisionsBetweenF = await(adminApi.history(filePath, tBeginUpdate, tEndUpdate)).map(_.id)
 
       // take last two revisions
-      await(adminApi.history(filePath, maxResults = 2)).map(_.id) shouldBe List(id2, id1)
+      val last2RevisionsF = await(adminApi.history(filePath, maxResults = 2)).map(_.id)
+      // #history
+      fullHistory.map(_.id) shouldBe List(id2, id1, id0)
+      fullHistory.map(_.comment) shouldBe List("third commit", "second commit", "first commit")
+      revisionsBetweenF shouldBe List(id2, id1)
+      last2RevisionsF shouldBe List(id2, id1)
     }
     Await.result(assertionF, 3.seconds)
-    // #history
+
   }
 
   test("historyActive-setActiveVersion-resetActiveVersion-getActiveVersion-getActiveByTime | DEOPSCSW-89, DEOPSCSW-592") {
@@ -294,10 +320,11 @@ class ConfigClientExample
       val tBegin   = Instant.now()
       val filePath = Paths.get("/a/test.conf")
       // create will make the 1st revision active with a default comment
-      val id1 = await(adminApi.create(filePath, ConfigData.fromString(defaultStrConf), annex = false, "first"))
-      await(adminApi.historyActive(filePath)).map(_.id) shouldBe List(id1)
+      val id1      = await(adminApi.create(filePath, ConfigData.fromString(defaultStrConf), annex = false, "first"))
+      val activeId = await(adminApi.historyActive(filePath)).map(_.id)
+
       // ensure active version is set
-      await(adminApi.getActiveVersion(filePath)).get shouldBe id1
+      val activeVersionF = await(adminApi.getActiveVersion(filePath)).get
 
       // override the contents four times
       await(adminApi.update(filePath, ConfigData.fromString("changing contents"), "second"))
@@ -306,22 +333,38 @@ class ConfigClientExample
       val id5 = await(adminApi.update(filePath, ConfigData.fromString("final final contents"), "fifth"))
 
       // update doesn't change the active revision
-      await(adminApi.historyActive(filePath)).map(_.id) shouldBe List(id1)
-
+      val idList = await(adminApi.historyActive(filePath)).map(_.id)
       // play with active version
       await(adminApi.setActiveVersion(filePath, id3, s"$id3 active"))
       await(adminApi.setActiveVersion(filePath, id4, s"$id4 active"))
-      await(adminApi.getActiveVersion(filePath)).get shouldBe id4
+      val id4F = await(adminApi.getActiveVersion(filePath)).get
       val tEnd = Instant.now()
       // reset active version to latest
       await(adminApi.resetActiveVersion(filePath, "latest active"))
-      await(adminApi.getActiveVersion(filePath)).get shouldBe id5
+      val id5F = await(adminApi.getActiveVersion(filePath)).get
+
       // finally set initial version as active
       await(adminApi.setActiveVersion(filePath, id1, s"$id1 active"))
-      await(adminApi.getActiveVersion(filePath)).get shouldBe id1
+      val id1F = await(adminApi.getActiveVersion(filePath)).get
 
-      // validate full history
+      //  get full history
       val fullHistory = await(adminApi.historyActive(filePath))
+
+      // drop initial revision and take only update revisions
+      val fragmentedHistory = await(adminApi.historyActive(filePath, tBegin, tEnd))
+
+      // take last three revisions
+      val last3Revisions = await(adminApi.historyActive(filePath, maxResults = 3)).map(_.id)
+
+      // get contents of active version at a specified instance
+      val initialContents       = await(adminApi.getActiveByTime(filePath, tBegin)).get
+      val initialContentsParseF = await(initialContents.toStringF(actorSystem))
+      // #active-file-mgmt
+
+      fragmentedHistory.size shouldBe 3
+      last3Revisions shouldBe List(id1, id5, id4)
+      initialContentsParseF shouldBe defaultStrConf
+      activeId shouldBe List(id1)
       fullHistory.map(_.id) shouldBe List(id1, id5, id4, id3, id1)
       fullHistory.map(_.comment) shouldBe List(
         s"$id1 active",
@@ -330,30 +373,24 @@ class ConfigClientExample
         s"$id3 active",
         "initializing active file with the first version"
       )
-
-      // drop initial revision and take only update revisions
-      val fragmentedHistory = await(adminApi.historyActive(filePath, tBegin, tEnd))
-      fragmentedHistory.size shouldBe 3
-
-      // take last three revisions
-      await(adminApi.historyActive(filePath, maxResults = 3)).map(_.id) shouldBe List(id1, id5, id4)
-
-      // get contents of active version at a specified instance
-      val initialContents = await(adminApi.getActiveByTime(filePath, tBegin)).get
-      await(initialContents.toStringF(actorSystem)) shouldBe defaultStrConf
+      activeVersionF shouldBe id1
+      id4F shouldBe id4
+      id5F shouldBe id5
+      id1F shouldBe id1
+      idList shouldBe List(id1)
     }
     Await.result(assertionF, 5.seconds)
-    // #active-file-mgmt
   }
 
   test("getMetadata | DEOPSCSW-89, DEOPSCSW-592") {
     // #getMetadata
     val assertF = async {
       val metaData: ConfigMetadata = await(adminApi.getMetadata)
-      // repository path must not be empty
+      //  metaData.repoPath returns repository path
+      // #getMetadata
       metaData.repoPath should not be empty
     }
     Await.result(assertF, 2.seconds)
-    // #getMetadata
+
   }
 }

--- a/examples/src/test/scala/example/params/CommandsExample.scala
+++ b/examples/src/test/scala/example/params/CommandsExample.scala
@@ -14,7 +14,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 // DEOPSCSW-196: Command Payloads for variable command content
-class CommandsTest extends AnyFunSpec with Matchers {
+class CommandsExample extends AnyFunSpec with Matchers {
 
   // #obsid
   val obsId: ObsId = ObsId("2020A-001-123")

--- a/examples/src/test/scala/example/params/EventsExample.scala
+++ b/examples/src/test/scala/example/params/EventsExample.scala
@@ -12,7 +12,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 //DEOPSCSW-331: Event Service Accessible to all CSW component builders
-class EventsTest extends AnyFunSpec with Matchers {
+class EventsExample extends AnyFunSpec with Matchers {
 
   describe("Examples of EventTime") {
     it("should show usage of utility functions") {

--- a/examples/src/test/scala/example/params/KeysAndParametersExample.scala
+++ b/examples/src/test/scala/example/params/KeysAndParametersExample.scala
@@ -10,7 +10,7 @@ import csw.time.core.models.{TAITime, UTCTime}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class KeysAndParametersTest extends AnyFunSpec with Matchers {
+class KeysAndParametersExample extends AnyFunSpec with Matchers {
   // DEOPSCSW-196: Command Payloads for variable command content
   describe("Examples of keys and parameters") {
 

--- a/examples/src/test/scala/example/params/ResultExample.scala
+++ b/examples/src/test/scala/example/params/ResultExample.scala
@@ -9,7 +9,7 @@ import csw.prefix.models.Prefix
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class ResultTest extends AnyFunSpec with Matchers {
+class ResultExample extends AnyFunSpec with Matchers {
 
   // #runid
   val runId: Id = Id()

--- a/examples/src/test/scala/example/params/StateVariablesExample.scala
+++ b/examples/src/test/scala/example/params/StateVariablesExample.scala
@@ -11,7 +11,7 @@ import csw.time.core.models.UTCTime
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class StateVariablesTest extends AnyFunSpec with Matchers {
+class StateVariablesExample extends AnyFunSpec with Matchers {
   describe("Examples of State variables") {
 
     it("should show usages of DemandState") {

--- a/examples/src/test/scala/example/teskit/ScalaAlarmTestKitExample.scala
+++ b/examples/src/test/scala/example/teskit/ScalaAlarmTestKitExample.scala
@@ -9,7 +9,7 @@ import csw.testkit.scaladsl.ScalaTestFrameworkTestKit
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 //#scalatest-alarm-testkit
-class ScalaAlarmTestKitExampleTest extends ScalaTestFrameworkTestKit(AlarmServer) with AnyFunSuiteLike {
+class ScalaAlarmTestKitExample extends ScalaTestFrameworkTestKit(AlarmServer) with AnyFunSuiteLike {
   import frameworkTestKit.alarmTestKit._
   test("test initializing alarms via config") {
     initAlarms(ConfigFactory.parseResources("valid-alarms.conf"))

--- a/examples/src/test/scala/example/teskit/ScalaDatabaseTestKitExample.scala
+++ b/examples/src/test/scala/example/teskit/ScalaDatabaseTestKitExample.scala
@@ -18,6 +18,7 @@ class ScalaDatabaseTestKitExample extends ScalaTestFrameworkTestKit(DatabaseServ
   }
 
   test("test using database service factory") {
+    // Usage of Await.result is fine in test scope here, as `databaseServiceFactory().makeDsl()` returns Future.
     val queryDsl = Await.result(databaseServiceFactory().makeDsl(frameworkTestKit.locationService, "postgres"), 2.seconds)
     // .. queries, assertions etc.
   }

--- a/examples/src/test/scala/example/teskit/ScalaDatabaseTestKitExample.scala
+++ b/examples/src/test/scala/example/teskit/ScalaDatabaseTestKitExample.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration.DurationInt
 
 //#CSW-161
 //#scalatest-database-testkit
-class ScalaDatabaseTestKitExampleTest extends ScalaTestFrameworkTestKit(DatabaseServer) with AnyFunSuiteLike {
+class ScalaDatabaseTestKitExample extends ScalaTestFrameworkTestKit(DatabaseServer) with AnyFunSuiteLike {
   import frameworkTestKit.databaseTestKit.*
 
   test("test using dsl context") {

--- a/examples/src/test/scala/example/teskit/ScalaTestIntegrationExample.scala
+++ b/examples/src/test/scala/example/teskit/ScalaTestIntegrationExample.scala
@@ -6,7 +6,7 @@ import csw.testkit.scaladsl.CSWService.{AlarmServer, EventServer}
 import csw.testkit.scaladsl.ScalaTestFrameworkTestKit
 import org.scalatest.funsuite.AnyFunSuiteLike
 
-class ScalaTestIntegrationExampleTest extends ScalaTestFrameworkTestKit(AlarmServer, EventServer) with AnyFunSuiteLike {
+class ScalaTestIntegrationExample extends ScalaTestFrameworkTestKit(AlarmServer, EventServer) with AnyFunSuiteLike {
 
   test("test spawning component in standalone mode") {
     spawnStandalone(ConfigFactory.load("SampleHcdStandalone.conf"))

--- a/examples/src/test/scala/example/teskit/TestKitsExample.scala
+++ b/examples/src/test/scala/example/teskit/TestKitsExample.scala
@@ -33,7 +33,7 @@ class TestKitsExample extends AnyFunSuiteLike with BeforeAndAfterAll with Matche
   override protected def afterAll(): Unit = frameworkTestKit.shutdown()
   // #framework-testkit
 
-  import frameworkTestKit._
+  import frameworkTestKit.*
 
   test("framework testkit example for spawning container") {
     // #spawn-using-testkit

--- a/examples/src/test/scala/example/teskit/TestKitsExample.scala
+++ b/examples/src/test/scala/example/teskit/TestKitsExample.scala
@@ -17,7 +17,7 @@ import org.tmt.csw.samplehcd.SampleHcdHandlers
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationLong
 
-class TestKitsExampleTest extends AnyFunSuiteLike with BeforeAndAfterAll with Matchers with OptionValues {
+class TestKitsExample extends AnyFunSuiteLike with BeforeAndAfterAll with Matchers with OptionValues {
 
   // Fix to avoid 'java.util.concurrent.RejectedExecutionException: Worker has already been shutdown'
   InternalLoggerFactory.setDefaultFactory(InternalLoggerFactory.getDefaultFactory)

--- a/integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala
+++ b/integration/src/multi-jvm/scala/csw/framework/command/CommandServiceTest.scala
@@ -136,7 +136,6 @@ class CommandServiceTest(ignore: Int)
       Await.result(Standalone.spawn(assemblyConf, wiring), 5.seconds)
       enterBarrier("spawned")
 
-      println(Await.result(locationService.list, 10.seconds))
       // resolve assembly running in jvm-3 and send setup command expecting immediate command completion response
       val assemblyLocF =
         locationService.resolve(

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -21,8 +21,8 @@ object Common {
 
   val MaybeCoverage: Plugins = if (enableCoverage) Coverage else Plugins.empty
   val jsTestArg              = Test / testOptions := Seq(Tests.Argument("-oDF"))
-
   lazy val CommonSettings: Seq[Setting[_]] = Seq(
+    
     docsRepo                                        := "https://github.com/tmtsoftware/tmtsoftware.github.io.git",
     docsParentDir                                   := "csw",
     gitCurrentRepo                                  := "https://github.com/tmtsoftware/csw",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ addSbtPlugin("com.dwijnand"                      % "sbt-project-graph"         %
 addSbtPlugin("com.timushev.sbt"                  % "sbt-rewarn"                % "0.1.3")
 
 resolvers += "jitpack" at "https://jitpack.io"
-libraryDependencies += "com.github.tmtsoftware" % "sbt-docs" % "4bcadf7"
+libraryDependencies += "com.github.tmtsoftware" % "sbt-docs" % "115000a"
 
 classpathTypes += "maven-plugin"
 


### PR DESCRIPTION
1: Following tasks were done
  - Code snipped from csw-framework , integration module moved to examples folder.
  - In a sense,  Snippets from files like JCommandIntegrationTest , CommandServiceTest , SampleComponentHandlers , LongRunningCommandService , much more.. ([commit](https://github.com/tmtsoftware/csw/pull/416/commits/9d6e619127359bdf23b3870fd40af454c081e482))
are now getting snipped from files CurrentStateExampleComponentHandlers  , JCurrentStateExampleComponentHandlers.

2 : We already had source-link for all the snippets, it’s css was broken. so we have fixed it by providing a custom.css in csw docs site.
3: Updated relevent files which are getting snipped.
4: Updated file names & assert statements are now outside of snippet comments.
5 : Removed await.results where it was required and kept them at places where it was neccessary like : 
  - Initialisation / shutdown of component in handlers.
  - In tests where validation is done.

[Jira card](https://tmt-project.atlassian.net/browse/CSW-181)