### PR TITLE
#CSW-183: Manish | Chauhan: Replace scalatest+junit with sbt/junit-in…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -491,7 +491,7 @@ lazy val `csw-time-core` = crossProject(JSPlatform, JVMPlatform)
   .dependsOn(`csw-time-clock`)
   .jvmConfigure(_.enablePlugins(GenJavadocPlugin))
   .jsSettings(jsTestArg)
-  .jvmSettings(libraryDependencies += Libs.`junit-4-13` % Test)
+  .jvmSettings(libraryDependencies += Libs.`junit4-interface` % Test)
   .settings(
     libraryDependencies += Libs.`scalatest`.value % Test,
     fork                                         := false

--- a/csw-alarm/csw-alarm-client/src/test/java/csw/alarm/client/JAlarmRefreshActorTest.java
+++ b/csw-alarm/csw-alarm-client/src/test/java/csw/alarm/client/JAlarmRefreshActorTest.java
@@ -13,13 +13,12 @@ import csw.alarm.models.Key.AlarmKey;
 import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 //CSW-83:Alarm models should take prefix
-public class JAlarmRefreshActorTest extends JUnitSuite {
+public class JAlarmRefreshActorTest {
     private final ActorSystem<SpawnProtocol.Command> typedSystem = ActorSystem.apply(SpawnProtocol.create(), "SpawnProtocolGuardian");
 
     // DEOPSCSW-507: Auto-refresh utility for component developers

--- a/csw-alarm/csw-alarm-client/src/test/java/csw/alarm/client/JAlarmServiceFactoryTest.java
+++ b/csw-alarm/csw-alarm-client/src/test/java/csw/alarm/client/JAlarmServiceFactoryTest.java
@@ -16,7 +16,6 @@ import csw.location.client.javadsl.JHttpLocationServiceFactory;
 import csw.location.api.models.TcpRegistration;
 import csw.location.server.http.JHTTPLocationService;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
@@ -25,7 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 // DEOPSCSW-481: Component Developer API available to all CSW components
-public class JAlarmServiceFactoryTest extends JUnitSuite {
+public class JAlarmServiceFactoryTest {
     // start location http server
     private static final JHTTPLocationService jHttpLocationService = new JHTTPLocationService();
 

--- a/csw-alarm/csw-alarm-client/src/test/java/csw/alarm/client/internal/JSeverityServiceModuleTest.java
+++ b/csw-alarm/csw-alarm-client/src/test/java/csw/alarm/client/internal/JSeverityServiceModuleTest.java
@@ -15,7 +15,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -27,7 +26,7 @@ import static org.junit.Assert.*;
 
 // DEOPSCSW-444: Set severity api for component
 // CSW-83: Alarm models should take prefix
-public class JSeverityServiceModuleTest extends JUnitSuite {
+public class JSeverityServiceModuleTest {
 
     private static final AlarmServiceTestSetup alarmServiceTestSetup = new AlarmServiceTestSetup();
     private static final IAlarmService jAlarmService = alarmServiceTestSetup.jAlarmService();

--- a/csw-benchmark/src/main/java/csw/benchmark/logging/JE2ELoggingBenchmark.java
+++ b/csw-benchmark/src/main/java/csw/benchmark/logging/JE2ELoggingBenchmark.java
@@ -9,7 +9,6 @@ import csw.logging.client.javadsl.JGenericLoggerFactory;
 import csw.logging.client.javadsl.JLogAppenderBuilders;
 import csw.logging.client.javadsl.JLoggingSystemFactory;
 import org.openjdk.jmh.annotations.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -34,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
 @Fork(value = 1)
-public class JE2ELoggingBenchmark extends JUnitSuite {
+public class JE2ELoggingBenchmark {
     private ILogger log;
     private static ActorSystem<SpawnProtocol.Command> actorSystem;
     private JPerson person;

--- a/csw-config/csw-config-client/src/test/java/csw/config/client/javadsl/JConfigAdminApiTest.java
+++ b/csw-config/csw-config-client/src/test/java/csw/config/client/javadsl/JConfigAdminApiTest.java
@@ -12,7 +12,6 @@ import csw.config.models.ConfigFileRevision;
 import csw.config.models.ConfigId;
 import csw.config.models.ConfigMetadata;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.Some;
 
 import java.nio.file.Path;
@@ -32,7 +31,7 @@ import static org.mockito.Mockito.when;
 // DEOPSCSW-138: Split Config API into Admin API and Client API
 // DEOPSCSW-103: Java API for Configuration service
 @SuppressWarnings("unchecked")
-public class JConfigAdminApiTest extends JUnitSuite {
+public class JConfigAdminApiTest {
 
     private static JConfigClientBaseSuite jConfigClientBaseSuite;
     private static IConfigService configService;

--- a/csw-config/csw-config-client/src/test/java/csw/config/client/javadsl/JConfigClientApiTest.java
+++ b/csw-config/csw-config-client/src/test/java/csw/config/client/javadsl/JConfigClientApiTest.java
@@ -8,7 +8,6 @@ import csw.config.api.javadsl.IConfigService;
 import csw.config.client.JConfigClientBaseSuite;
 import csw.config.models.ConfigId;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -16,7 +15,7 @@ import java.util.concurrent.ExecutionException;
 
 // DEOPSCSW-138:Split Config API into Admin API and Client API
 // DEOPSCSW-103: Java API for Configuration service
-public class JConfigClientApiTest extends JUnitSuite {
+public class JConfigClientApiTest {
 
     private static JConfigClientBaseSuite jConfigClientBaseSuite;
     private static IConfigService configService;

--- a/csw-database/src/test/java/csw/database/JDatabaseServiceFactoryFailureTest.java
+++ b/csw-database/src/test/java/csw/database/JDatabaseServiceFactoryFailureTest.java
@@ -9,7 +9,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -18,7 +17,7 @@ import java.util.concurrent.ExecutionException;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 //DEOPSCSW-615: DB service accessible to CSW component developers
-public class JDatabaseServiceFactoryFailureTest extends JUnitSuite {
+public class JDatabaseServiceFactoryFailureTest {
 
     private static ActorSystem<SpawnProtocol.Command> system;
     private static EmbeddedPostgres postgres;

--- a/csw-database/src/test/java/csw/database/JDatabaseServiceFactoryTest.java
+++ b/csw-database/src/test/java/csw/database/JDatabaseServiceFactoryTest.java
@@ -13,7 +13,6 @@ import org.jooq.DSLContext;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -30,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 //DEOPSCSW-620: Session Creation to access data
 //DEOPSCSW-621: Session creation to access data with single connection
 //DEOPSCSW-615: DB service accessible to CSW component developers
-public class JDatabaseServiceFactoryTest extends JUnitSuite {
+public class JDatabaseServiceFactoryTest {
 
     private static final Integer port = 5432;
     private static JHTTPLocationService jHttpLocationService;

--- a/csw-database/src/test/java/csw/database/JDatabaseServiceTest.java
+++ b/csw-database/src/test/java/csw/database/JDatabaseServiceTest.java
@@ -14,7 +14,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -29,7 +28,7 @@ import static org.junit.Assert.*;
 
 //DEOPSCSW-601: Create Database API
 //DEOPSCSW-616: Create a method to send a query (select) sql string to a database
-public class JDatabaseServiceTest extends JUnitSuite {
+public class JDatabaseServiceTest {
     private static ActorSystem<SpawnProtocol.Command> system;
     private static EmbeddedPostgres postgres;
     private static DSLContext dsl;

--- a/csw-event/csw-event-client/src/test/java/csw/event/client/internal/kafka/JKafkaFailureTest.java
+++ b/csw-event/csw-event-client/src/test/java/csw/event/client/internal/kafka/JKafkaFailureTest.java
@@ -16,7 +16,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -29,7 +28,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 //DEOPSCSW-398: Propagate failure for publish api (eventGenerator)
-public class JKafkaFailureTest extends JUnitSuite {
+public class JKafkaFailureTest {
 
     private static KafkaTestProps kafkaTestProps;
     private static IEventPublisher publisher;

--- a/csw-event/csw-event-client/src/test/java/csw/event/client/internal/redis/JRedisFailureTest.java
+++ b/csw-event/csw-event-client/src/test/java/csw/event/client/internal/redis/JRedisFailureTest.java
@@ -15,7 +15,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -27,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 //DEOPSCSW-398: Propagate failure for publish api (eventGenerator)
-public class JRedisFailureTest extends JUnitSuite {
+public class JRedisFailureTest {
 
     private static RedisTestProps redisTestProps;
 

--- a/csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java
+++ b/csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java
@@ -96,11 +96,10 @@ public class JCommandIntegrationTest {
     }
 
     private static AkkaLocation getLocation() throws Exception {
-        RedisClient redisClient = null;
-        FrameworkWiring wiring = FrameworkWiring.make(hcdActorSystem, redisClient);
+        FrameworkWiring wiring = FrameworkWiring.make(hcdActorSystem, (RedisClient) null);
         Await.result(Standalone.spawn(ConfigFactory.load("aps_hcd_java.conf"), wiring), new FiniteDuration(5, TimeUnit.SECONDS));
 
-        AkkaConnection akkaConnection = new AkkaConnection(new ComponentId(Prefix.apply(JSubsystem.IRIS, "Test_Component_Running_Long_Command_Java"), JComponentType.HCD));
+        AkkaConnection akkaConnection = new AkkaConnection(new ComponentId(Prefix.apply(JSubsystem.IRIS, "test_component_running_long_command_java"), JComponentType.HCD));
         CompletableFuture<Optional<AkkaLocation>> eventualLocation = locationService.resolve(akkaConnection, java.time.Duration.ofSeconds(5));
         Optional<AkkaLocation> maybeLocation = eventualLocation.get();
         Assert.assertTrue(maybeLocation.isPresent());
@@ -362,7 +361,9 @@ public class JCommandIntegrationTest {
         CompletableFuture<SubmitResponse> shortSubmit = hcdCmdService.submitAndWait(qfAllSetup1, timeout);
         CompletableFuture<SubmitResponse> mediumSubmit = hcdCmdService.submitAndWait(qfAllSetup2, timeout);
         CompletableFuture<SubmitResponse> longSubmit = hcdCmdService.submitAndWait(qfAllSetup3, timeout);
-
+        shortSubmit.get();
+        mediumSubmit.get();
+        longSubmit.get();
 
         //#queryF
 

--- a/csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java
+++ b/csw-framework/src/test/java/csw/framework/command/JCommandIntegrationTest.java
@@ -18,11 +18,11 @@ import csw.framework.internal.wiring.FrameworkWiring;
 import csw.framework.internal.wiring.Standalone;
 import csw.location.api.javadsl.ILocationService;
 import csw.location.api.javadsl.JComponentType;
-import csw.location.client.ActorSystemFactory;
-import csw.location.client.javadsl.JHttpLocationServiceFactory;
 import csw.location.api.models.AkkaLocation;
 import csw.location.api.models.ComponentId;
 import csw.location.api.models.Connection.AkkaConnection;
+import csw.location.client.ActorSystemFactory;
+import csw.location.client.javadsl.JHttpLocationServiceFactory;
 import csw.location.server.http.JHTTPLocationService;
 import csw.params.commands.CommandIssue;
 import csw.params.commands.CommandResponse;
@@ -37,15 +37,14 @@ import csw.params.core.states.DemandState;
 import csw.params.core.states.StateName;
 import csw.params.javadsl.JKeyType;
 import csw.params.javadsl.JUnits;
-import csw.prefix.models.Prefix;
 import csw.prefix.javadsl.JSubsystem;
+import csw.prefix.models.Prefix;
 import io.lettuce.core.RedisClient;
 import msocket.api.Subscription;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
@@ -70,7 +69,7 @@ import static csw.common.components.command.ComponentStateForCommand.*;
 // DEOPSCSW-317: Use state values of HCD to determine command completion
 // DEOPSCSW-321: AkkaLocation provides wrapper for ActorRef[ComponentMessage]
 @SuppressWarnings("unchecked")
-public class JCommandIntegrationTest extends JUnitSuite {
+public class JCommandIntegrationTest {
     private static final ActorSystem<SpawnProtocol.Command> hcdActorSystem = ActorSystemFactory.remote(SpawnProtocol.create(), "test");
 
     private static JHTTPLocationService jHttpLocationService;
@@ -363,8 +362,6 @@ public class JCommandIntegrationTest extends JUnitSuite {
         CompletableFuture<SubmitResponse> shortSubmit = hcdCmdService.submitAndWait(qfAllSetup1, timeout);
         CompletableFuture<SubmitResponse> mediumSubmit = hcdCmdService.submitAndWait(qfAllSetup2, timeout);
         CompletableFuture<SubmitResponse> longSubmit = hcdCmdService.submitAndWait(qfAllSetup3, timeout);
-
-        
 
 
         //#queryF

--- a/csw-location/csw-location-server/src/test/java/csw/location/server/javadsl/JLocationServiceImplTest.java
+++ b/csw-location/csw-location-server/src/test/java/csw/location/server/javadsl/JLocationServiceImplTest.java
@@ -28,7 +28,6 @@ import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import msocket.api.Subscription;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -41,7 +40,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-public class JLocationServiceImplTest extends JUnitSuite {
+public class JLocationServiceImplTest {
 
     private static ServerWiring wiring;
 

--- a/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/ILoggerActorTest.java
+++ b/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/ILoggerActorTest.java
@@ -17,7 +17,6 @@ import csw.logging.models.Level;
 import csw.logging.models.Level$;
 import csw.prefix.models.Prefix;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -30,7 +29,7 @@ import static csw.logging.client.utils.Eventually.eventually;
 // CSW-78: PrefixRedesign for logging
 // CSW-86: Subsystem should be case-insensitive
 // DEOPSCSW-316: Improve Logger accessibility for component developers
-public class ILoggerActorTest extends JUnitSuite {
+public class ILoggerActorTest {
     protected static final ActorSystem<SpawnProtocol.Command> actorSystem = ActorSystem.create(SpawnProtocol.create(), "base-system");
     protected static LoggingSystem loggingSystem;
 

--- a/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/ILoggerMutableActorTest.java
+++ b/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/ILoggerMutableActorTest.java
@@ -18,7 +18,6 @@ import csw.logging.client.internal.LoggingSystem;
 import csw.logging.client.utils.TestAppender;
 import csw.prefix.models.Prefix;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -31,7 +30,7 @@ import static csw.logging.client.utils.Eventually.eventually;
 // DEOPSCSW-280 SPIKE: Introduce Akkatyped in logging
 // CSW-78: PrefixRedesign for logging
 // CSW-86: Subsystem should be case-insensitive
-public class ILoggerMutableActorTest extends JUnitSuite {
+public class ILoggerMutableActorTest {
     protected static final ActorSystem<SpawnProtocol.Command> actorSystem = ActorSystem.create(SpawnProtocol.create(), "base-system");
     protected static LoggingSystem loggingSystem;
 

--- a/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/ILoggerTest.java
+++ b/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/ILoggerTest.java
@@ -23,7 +23,6 @@ import csw.logging.client.utils.JLogUtil;
 import csw.logging.client.utils.TestAppender;
 import csw.prefix.models.Prefix;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -38,7 +37,7 @@ import static csw.logging.client.utils.Eventually.eventually;
 // DEOPSCSW-316: Improve Logger accessibility for component developers
 // CSW-78: PrefixRedesign for logging
 // CSW-86: Subsystem should be case-insensitive
-public class ILoggerTest extends JUnitSuite {
+public class ILoggerTest {
     private static final ActorSystem<SpawnProtocol.Command> actorSystem = ActorSystem.create(SpawnProtocol.create(), "base-system");
     private static LoggingSystem loggingSystem;
 

--- a/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/JGenericLoggerTest.java
+++ b/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/JGenericLoggerTest.java
@@ -17,7 +17,6 @@ import csw.logging.client.utils.JGenericActor;
 import csw.logging.client.utils.JLogUtil;
 import csw.logging.client.utils.TestAppender;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -28,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import static csw.logging.client.utils.Eventually.eventually;
 
 // DEOPSCSW-316: Improve Logger accessibility for component developers
-public class JGenericLoggerTest extends JUnitSuite {
+public class JGenericLoggerTest {
     private static final ActorSystem<SpawnProtocol.Command> actorSystem = ActorSystem.create(SpawnProtocol.create(), "base-system");
     private static LoggingSystem loggingSystem;
 

--- a/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/JLoggerImplAPITest.java
+++ b/csw-logging/csw-logging-client/src/test/java/csw/logging/client/javadsl/JLoggerImplAPITest.java
@@ -14,7 +14,6 @@ import csw.logging.client.commons.LoggingKeys$;
 import csw.logging.client.internal.LoggingSystem;
 import csw.logging.client.utils.TestAppender;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
@@ -30,7 +29,7 @@ import static csw.logging.client.utils.Eventually.eventually;
 // DEOPSCSW-158: Logging service API implementation details to be hidden from component developer
 // DEOPSCSW-271: API change
 // DEOPSCSW-278: Create Java API without arguments as suppliers
-public class JLoggerImplAPITest extends JUnitSuite {
+public class JLoggerImplAPITest {
 
     private final ILogger logger = JGenericLoggerFactory.getLogger(getClass());
 

--- a/csw-params/jvm/src/test/java/csw/params/commands/JCommandsTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/commands/JCommandsTest.java
@@ -10,7 +10,6 @@ import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -18,7 +17,7 @@ import java.util.stream.Collectors;
 // DEOPSCSW-183: Configure attributes and values
 // DEOPSCSW-185: Easy to Use Syntax/Api
 // DEOPSCSW-320: Add command type in Setup, observe and wait
-public class JCommandsTest extends JUnitSuite {
+public class JCommandsTest {
 
     private final Key<Integer> encoderIntKey = JKeyType.IntKey().make("encoder", JUnits.encoder);
     private final Key<String> epochStringKey = JKeyType.StringKey().make("epoch", JUnits.year);

--- a/csw-params/jvm/src/test/java/csw/params/core/generics/JArrayKeyTypeTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/generics/JArrayKeyTypeTest.java
@@ -5,7 +5,6 @@ import csw.params.core.models.ArrayData;
 import csw.params.core.models.Units;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.List;
 
@@ -15,7 +14,7 @@ import static csw.params.javadsl.JUnits.*;
 // DEOPSCSW-190: Implement Unit Support
 // DEOPSCSW-184: Change configurations - attributes and values
 @SuppressWarnings("unchecked")
-public class JArrayKeyTypeTest extends JUnitSuite {
+public class JArrayKeyTypeTest {
 
     private void commonAssertions(String keyName, KeyType<?> keyType, ArrayData<?>[] testData, Parameter<?> parameter, Units unit) {
         Assert.assertEquals(keyName, keyName);

--- a/csw-params/jvm/src/test/java/csw/params/core/generics/JChoiceKeyTypeTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/generics/JChoiceKeyTypeTest.java
@@ -5,7 +5,6 @@ import csw.params.core.models.Choices;
 import csw.params.javadsl.JKeyType;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,7 +13,7 @@ import static csw.params.javadsl.JUnits.kilometer;
 
 // DEOPSCSW-183: Configure attributes and values
 // DEOPSCSW-190: Implement Unit Support
-public class JChoiceKeyTypeTest extends JUnitSuite {
+public class JChoiceKeyTypeTest {
     private final String keyName = " choiceKey";
     private final Choices choices = Choices.from("A", "B", "C");
 

--- a/csw-params/jvm/src/test/java/csw/params/core/generics/JMatrixKeyTypeTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/generics/JMatrixKeyTypeTest.java
@@ -7,7 +7,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +19,7 @@ import static csw.params.javadsl.JUnits.*;
 // DEOPSCSW-184: Change configurations - attributes and values
 @SuppressWarnings("RedundantCast") // false negative, test fails if you remove explicit type.
 @RunWith(value = Parameterized.class)
-public class JMatrixKeyTypeTest extends JUnitSuite {
+public class JMatrixKeyTypeTest {
 
     private final String keyName;
     private final SimpleKeyType<MatrixData<?>> matrixKey;

--- a/csw-params/jvm/src/test/java/csw/params/core/generics/JSimpleKeyTypeTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/generics/JSimpleKeyTypeTest.java
@@ -5,7 +5,6 @@ import csw.time.core.models.TAITime;
 import csw.time.core.models.UTCTime;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Instant;
 
@@ -16,7 +15,7 @@ import static csw.params.javadsl.JUnits.*;
 // DEOPSCSW-190: Implement Unit Support
 // DEOPSCSW-184: Change configurations - attributes and values
 @SuppressWarnings({"RedundantCast", "unchecked"}) // false negative, test fails if you remove explicit type.
-public class JSimpleKeyTypeTest extends JUnitSuite {
+public class JSimpleKeyTypeTest {
 
     @Test
     public void testBooleanKeyParameter__DEOPSCSW_183_DEOPSCSW_185_DEOPSCSW_190_DEOPSCSW_184() {

--- a/csw-params/jvm/src/test/java/csw/params/core/models/JAngleTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/models/JAngleTest.java
@@ -1,14 +1,13 @@
 package csw.params.core.models;
 
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.Tuple2;
 
 import static org.junit.Assert.*;
 import static csw.params.core.models.JAngle.*;
 
 // Tests the Angle class usage from Java (including helper methods in JAngle)
-public class JAngleTest extends JUnitSuite {
+public class JAngleTest {
     private final double delta = 0.00000001;
 
     // Basic parsing of radec as strings

--- a/csw-params/jvm/src/test/java/csw/params/core/models/JArrayDataTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/models/JArrayDataTest.java
@@ -2,11 +2,10 @@ package csw.params.core.models;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 // DEOPSCSW-183: Configure attributes and values
 @SuppressWarnings("RedundantCast") // false negative, test fails if you remove explicit type.
-public class JArrayDataTest extends JUnitSuite {
+public class JArrayDataTest {
 
     @Test
     public void shouldCreateArrayDataFromJavaArray__DEOPSCSW_183() {

--- a/csw-params/jvm/src/test/java/csw/params/core/models/JMatrixDataTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/models/JMatrixDataTest.java
@@ -2,11 +2,10 @@ package csw.params.core.models;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 // DEOPSCSW-183: Configure attributes and values
 @SuppressWarnings("RedundantCast") // false negative, test fails if you remove explicit type.
-public class JMatrixDataTest extends JUnitSuite {
+public class JMatrixDataTest {
 
     @Test
     public void shouldCreateMatrixDataFromJavaArrays__DEOPSCSW_183() {

--- a/csw-params/jvm/src/test/java/csw/params/core/states/JStateVariableTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/core/states/JStateVariableTest.java
@@ -11,7 +11,6 @@ import csw.prefix.models.Prefix;
 import csw.prefix.javadsl.JSubsystem;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +19,7 @@ import java.util.Set;
 
 // DEOPSCSW-183: Configure attributes and values
 // DEOPSCSW-185: Easy to Use Syntax/Api
-public class JStateVariableTest extends JUnitSuite {
+public class JStateVariableTest {
 
     private final Key<Integer> encoderIntKey = JKeyType.IntKey().make("encoder", JUnits.encoder);
     private final Key<String> epochStringKey = JKeyType.StringKey().make("epoch", JUnits.year);

--- a/csw-params/jvm/src/test/java/csw/params/events/JEventsTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/events/JEventsTest.java
@@ -9,7 +9,6 @@ import csw.prefix.models.Prefix;
 import csw.prefix.javadsl.JSubsystem;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -19,7 +18,7 @@ import java.util.stream.Collectors;
 // DEOPSCSW-327: Define Event Data Structure
 // DEOPSCSW-328: Basic information of Event needed for routing and Diagnostic use
 // DEOPSCSW-329: Providing Mandatory information during Event Creation
-public class JEventsTest extends JUnitSuite {
+public class JEventsTest {
     private final Key<Integer> encoderIntKey = JKeyType.IntKey().make("encoder", JUnits.encoder);
     private final Key<String> epochStringKey = JKeyType.StringKey().make("epoch", JUnits.year);
     private final Key<Integer> epochIntKey = JKeyType.IntKey().make("epoch", JUnits.year);

--- a/csw-params/jvm/src/test/java/csw/params/events/JIRDetectorEventTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/events/JIRDetectorEventTest.java
@@ -7,13 +7,12 @@ import csw.params.javadsl.JUnits;
 import csw.prefix.models.Prefix;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.*;
 
 import static csw.prefix.javadsl.JSubsystem.ESW;
 
-public class JIRDetectorEventTest extends JUnitSuite {
+public class JIRDetectorEventTest {
     Prefix sourcePrefix = new Prefix(ESW, "filter.wheel");
     ObsId obsId = ObsId.apply("2020A-001-123");
     Parameter<String> obsIdParam = JKeyType.StringKey().make("obsId").set(obsId.toString());

--- a/csw-params/jvm/src/test/java/csw/params/events/JOpticalDetectorEventTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/events/JOpticalDetectorEventTest.java
@@ -11,11 +11,10 @@ import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.*;
 
-public class JOpticalDetectorEventTest extends JUnitSuite {
+public class JOpticalDetectorEventTest {
     final Prefix sourcePrefix = new Prefix(JSubsystem.ESW, "filter.wheel");
     final ObsId obsId = ObsId.apply("2020A-001-123");
 

--- a/csw-params/jvm/src/test/java/csw/params/events/JSequencerObserveEventTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/events/JSequencerObserveEventTest.java
@@ -11,11 +11,10 @@ import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.*;
 
-public class JSequencerObserveEventTest extends JUnitSuite {
+public class JSequencerObserveEventTest {
     final Prefix prefix = new Prefix(JSubsystem.ESW, "filter.wheel");
     final ObsId obsId = ObsId.apply("2020A-001-123");
     final ExposureId exposureId = ExposureId.fromString("2021A-001-123-TCS-DET-SCI2-1234");

--- a/csw-params/jvm/src/test/java/csw/params/events/JWFSDetectorEventTest.java
+++ b/csw-params/jvm/src/test/java/csw/params/events/JWFSDetectorEventTest.java
@@ -9,12 +9,11 @@ import csw.prefix.javadsl.JSubsystem;
 import csw.prefix.models.Prefix;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class JWFSDetectorEventTest extends JUnitSuite {
+public class JWFSDetectorEventTest {
     Prefix sourcePrefix = new Prefix(JSubsystem.ESW, "filter.wheel");
     ExposureId exposureId = ExposureId.fromString("2022A-001-123-IRIS-IMG-DRK1-0023");
 

--- a/csw-params/jvm/src/test/scala/csw/params/core/formats/JCborTest.java
+++ b/csw-params/jvm/src/test/scala/csw/params/core/formats/JCborTest.java
@@ -14,7 +14,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.List;
@@ -22,7 +21,7 @@ import java.util.List;
 // DEOPSCSW-495: Protobuf serde fails for Java keys/parameters
 @SuppressWarnings("unchecked")
 @RunWith(value = Parameterized.class)
-public class JCborTest extends JUnitSuite {
+public class JCborTest {
 
     private final String keyType;
     private final Parameter<?> param;

--- a/csw-testkit/src/test/java/csw/testkit/javadsl/FrameworkTestKitJunitTest.java
+++ b/csw-testkit/src/test/java/csw/testkit/javadsl/FrameworkTestKitJunitTest.java
@@ -17,14 +17,13 @@ import csw.testkit.AlarmTestKit;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 // DEOPSCSW-592: Create csw testkit for component writers
-public class FrameworkTestKitJunitTest extends JUnitSuite {
+public class FrameworkTestKitJunitTest {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/csw-time/csw-time-core/jvm/src/test/java/csw/time/core/JTMTTimeHelperTest.java
+++ b/csw-time/csw-time-core/jvm/src/test/java/csw/time/core/JTMTTimeHelperTest.java
@@ -6,7 +6,6 @@ import csw.time.core.models.utils.TestProperties;
 import csw.time.core.models.utils.TestUtil;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -16,7 +15,7 @@ import java.time.ZonedDateTime;
 import static csw.time.core.utils.Eventually.eventually;
 import static org.junit.Assert.assertFalse;
 
-public class JTMTTimeHelperTest extends JUnitSuite {
+public class JTMTTimeHelperTest {
     private final TestProperties testProperties = JTestProperties.instance();
 
     //DEOPSCSW-541: PTP accuracy and precision while reading remote location time

--- a/csw-time/csw-time-core/jvm/src/test/java/csw/time/core/models/JTMTTimeTest.java
+++ b/csw-time/csw-time-core/jvm/src/test/java/csw/time/core/models/JTMTTimeTest.java
@@ -5,7 +5,6 @@ import csw.time.core.models.utils.JTestProperties;
 import csw.time.core.models.utils.TestProperties;
 import csw.time.core.models.utils.TestUtil;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.time.Duration;
@@ -15,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class JTMTTimeTest extends JUnitSuite {
+public class JTMTTimeTest {
 
     private static final int TaiOffset = TimeConstants$.MODULE$.taiOffset();
     private final int jitter = 100;

--- a/csw-time/csw-time-scheduler/src/test/java/csw/time/scheduler/api/JTimeServiceSchedulerTest.java
+++ b/csw-time/csw-time-scheduler/src/test/java/csw/time/scheduler/api/JTimeServiceSchedulerTest.java
@@ -11,7 +11,6 @@ import csw.time.core.models.TAITime;
 import csw.time.scheduler.TimeServiceSchedulerFactory;
 import org.junit.Rule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.time.Duration;
@@ -21,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
-public class JTimeServiceSchedulerTest extends JUnitSuite {
+public class JTimeServiceSchedulerTest {
 
     @Rule
     public final TestKitJunitResource testKit = new TestKitJunitResource(ManualTime.config());

--- a/examples/src/test/java/example/config/JConfigClientExampleTest.java
+++ b/examples/src/test/java/example/config/JConfigClientExampleTest.java
@@ -18,7 +18,6 @@ import csw.testkit.ConfigTestKit;
 import csw.testkit.javadsl.FrameworkTestKitJunitResource;
 import csw.testkit.javadsl.JCSWService;
 import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,7 +30,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
-public class JConfigClientExampleTest extends JUnitSuite {
+public class JConfigClientExampleTest {
 
     // DEOPSCSW-592: Create csw testkit for component writers
     @ClassRule

--- a/examples/src/test/java/example/params/JCommandsTest.java
+++ b/examples/src/test/java/example/params/JCommandsTest.java
@@ -17,7 +17,6 @@ import csw.params.javadsl.JUnits;
 import csw.time.core.models.UTCTime;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import play.api.libs.json.JsValue;
 import play.api.libs.json.Json;
 
@@ -26,7 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
-public class JCommandsTest extends JUnitSuite {
+public class JCommandsTest {
     //#obsid
     final ObsId obsId = ObsId.apply("2020A-001-123");
     //#obsid

--- a/examples/src/test/java/example/params/JEventsTest.java
+++ b/examples/src/test/java/example/params/JEventsTest.java
@@ -19,7 +19,6 @@ import csw.params.javadsl.JUnits;
 import csw.time.core.models.UTCTime;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import play.api.libs.json.JsValue;
 import play.api.libs.json.Json;
 
@@ -31,7 +30,7 @@ import java.util.stream.Collectors;
 
 //DEOPSCSW-331: Event Service Accessible to all CSW component builders
 @SuppressWarnings("unchecked")
-public class JEventsTest extends JUnitSuite {
+public class JEventsTest {
 
     @Test
     public void showUsageOfEventTime__DEOPSCSW_331() {

--- a/examples/src/test/java/example/params/JKeysAndParametersTest.java
+++ b/examples/src/test/java/example/params/JKeysAndParametersTest.java
@@ -10,7 +10,6 @@ import csw.time.core.models.TAITime;
 import csw.time.core.models.UTCTime;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.*;
 
@@ -18,7 +17,7 @@ import static csw.params.core.models.Coords.*;
 import static csw.params.core.models.JCoords.*;
 
 @SuppressWarnings({"unused", "RedundantCast", "unchecked", "ArraysAsListWithZeroOrOneArgument"})
-public class JKeysAndParametersTest extends JUnitSuite {
+public class JKeysAndParametersTest {
 
     @Test
     public void showUsageOfPrimitiveTypes() {

--- a/examples/src/test/java/example/params/JResultTest.java
+++ b/examples/src/test/java/example/params/JResultTest.java
@@ -13,7 +13,6 @@ import csw.prefix.models.Prefix;
 import csw.prefix.javadsl.JSubsystem;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import play.api.libs.json.JsValue;
 import play.api.libs.json.Json;
 
@@ -23,7 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
-public class JResultTest extends JUnitSuite {
+public class JResultTest {
 
     //#runid
     Id runId = Id.apply();

--- a/examples/src/test/java/example/params/JStateVariablesTest.java
+++ b/examples/src/test/java/example/params/JStateVariablesTest.java
@@ -15,7 +15,6 @@ import csw.prefix.javadsl.JSubsystem;
 import csw.time.core.models.UTCTime;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 import play.api.libs.json.JsValue;
 import play.api.libs.json.Json;
 
@@ -28,7 +27,7 @@ import static csw.params.javadsl.JUnits.NoUnits;
 import static csw.params.javadsl.JUnits.meter;
 
 @SuppressWarnings("unchecked")
-public class JStateVariablesTest extends JUnitSuite {
+public class JStateVariablesTest {
 
     @Test
     public void showUsageOfDemandState() {

--- a/examples/src/test/java/example/testkit/JTestKitsExampleTest.java
+++ b/examples/src/test/java/example/testkit/JTestKitsExampleTest.java
@@ -17,13 +17,12 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
-public class JTestKitsExampleTest extends JUnitSuite {
+public class JTestKitsExampleTest {
 
     //#framework-testkit
     private static final FrameworkTestKit frameworkTestKit = FrameworkTestKit.create();

--- a/examples/src/test/java/example/testkit/JUnitAlarmTestKitExampleTest.java
+++ b/examples/src/test/java/example/testkit/JUnitAlarmTestKitExampleTest.java
@@ -10,12 +10,11 @@ import csw.testkit.javadsl.FrameworkTestKitJunitResource;
 import csw.testkit.javadsl.JCSWService;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 
 //#junit-alarm-testkit
-class JUnitAlarmTestKitExampleTest extends JUnitSuite {
+class JUnitAlarmTestKitExampleTest {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/examples/src/test/java/example/testkit/JUnitDatabaseTestKitExampleTest.java
+++ b/examples/src/test/java/example/testkit/JUnitDatabaseTestKitExampleTest.java
@@ -6,7 +6,6 @@ import csw.testkit.javadsl.JCSWService;
 import org.jooq.DSLContext;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
@@ -15,7 +14,7 @@ import java.util.concurrent.TimeoutException;
 
 //#CSW-161
 //#junit-database-testkit
-class JUnitDatabaseTestKitExampleTest extends JUnitSuite {
+class JUnitDatabaseTestKitExampleTest {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/examples/src/test/java/example/testkit/JUnitIntegrationExampleTest.java
+++ b/examples/src/test/java/example/testkit/JUnitIntegrationExampleTest.java
@@ -7,11 +7,10 @@ import csw.testkit.javadsl.FrameworkTestKitJunitResource;
 import csw.testkit.javadsl.JCSWService;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 
-public class JUnitIntegrationExampleTest extends JUnitSuite {
+public class JUnitIntegrationExampleTest {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/examples/src/test/java/org/tmt/csw/sample/JSampleTest.java
+++ b/examples/src/test/java/org/tmt/csw/sample/JSampleTest.java
@@ -13,7 +13,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -21,7 +20,7 @@ import java.util.concurrent.ExecutionException;
 
 // DEOPSCSW-39: examples of Location Service
 //#intro
-public class JSampleTest extends JUnitSuite {
+public class JSampleTest {
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =
             new FrameworkTestKitJunitResource(Arrays.asList(JCSWService.AlarmServer, JCSWService.EventServer));

--- a/examples/src/test/java/org/tmt/csw/samplehcd/JSampleHcdTest.java
+++ b/examples/src/test/java/org/tmt/csw/samplehcd/JSampleHcdTest.java
@@ -33,7 +33,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.util.*;
@@ -43,7 +42,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 //#setup
-public class JSampleHcdTest extends JUnitSuite {
+public class JSampleHcdTest {
 
     @ClassRule
     public static final FrameworkTestKitJunitResource testKit =

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -10,6 +10,8 @@ object Common {
   private val enableCoverage: Boolean      = sys.props.get("enableCoverage").contains("true")
   val storyReport: Boolean                 = sys.props.get("generateStoryReport").contains("true")
 
+  sys.props.update("RTM_PATH", file(".").getAbsolutePath + "/target/RTM")
+
   private val reporterOptions: Seq[Tests.Argument] =
     // "-oDF" - show full stack traces and test case durations
     // -C - to give fully qualified name of the custom reporter
@@ -66,7 +68,6 @@ object Common {
     // and the maven repo match
     version := sys.env.getOrElse("JITPACK_VERSION", "0.1.0-SNAPSHOT"),
     fork    := true,
-    Test / fork := false,
     Test / javaOptions ++= Seq("-Dakka.actor.serialize-messages=on"),
     autoCompilerPlugins     := true,
     Global / cancelable     := true, // allow ongoing test(or any task) to cancel with ctrl + c and still remain inside sbt

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -66,7 +66,7 @@ object Common {
     // and the maven repo match
     version := sys.env.getOrElse("JITPACK_VERSION", "0.1.0-SNAPSHOT"),
     fork    := true,
-    Test / javaOptions ++= Seq("-Dakka.actor.serialize-messages=on", s"-DRTM_PATH=${file(".").getAbsolutePath + "/target/RTM"}"),
+    Test / javaOptions ++= Seq("-Dakka.actor.serialize-messages=on", s"-DRTM_PATH=${file("./target/RTM").getAbsolutePath}"),
     autoCompilerPlugins     := true,
     Global / cancelable     := true, // allow ongoing test(or any task) to cancel with ctrl + c and still remain inside sbt
     scalafmtOnCompile       := true,

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -66,7 +66,7 @@ object Common {
     // and the maven repo match
     version := sys.env.getOrElse("JITPACK_VERSION", "0.1.0-SNAPSHOT"),
     fork    := true,
-    Test / fork := true,
+    Test / fork := false,
     Test / javaOptions ++= Seq("-Dakka.actor.serialize-messages=on"),
     autoCompilerPlugins     := true,
     Global / cancelable     := true, // allow ongoing test(or any task) to cancel with ctrl + c and still remain inside sbt

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -10,8 +10,6 @@ object Common {
   private val enableCoverage: Boolean      = sys.props.get("enableCoverage").contains("true")
   val storyReport: Boolean                 = sys.props.get("generateStoryReport").contains("true")
 
-  sys.props.update("RTM_PATH", file(".").getAbsolutePath + "/target/RTM")
-
   private val reporterOptions: Seq[Tests.Argument] =
     // "-oDF" - show full stack traces and test case durations
     // -C - to give fully qualified name of the custom reporter
@@ -68,7 +66,7 @@ object Common {
     // and the maven repo match
     version := sys.env.getOrElse("JITPACK_VERSION", "0.1.0-SNAPSHOT"),
     fork    := true,
-    Test / javaOptions ++= Seq("-Dakka.actor.serialize-messages=on"),
+    Test / javaOptions ++= Seq("-Dakka.actor.serialize-messages=on", s"-DRTM_PATH=${file(".").getAbsolutePath + "/target/RTM"}"),
     autoCompilerPlugins     := true,
     Global / cancelable     := true, // allow ongoing test(or any task) to cancel with ctrl + c and still remain inside sbt
     scalafmtOnCompile       := true,

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -15,9 +15,10 @@ object Common {
     // -C - to give fully qualified name of the custom reporter
     if (storyReport)
       Seq(
-        Tests.Argument(TestFrameworks.ScalaTest, "-oDF", "-C", "tmt.test.reporter.TestReporter")
+        Tests.Argument(TestFrameworks.ScalaTest, "-oDF", "-C", "tmt.test.reporter.TestReporter"),
+        Tests.Argument(TestFrameworks.JUnit, "-v", "--run-listener=tmt.test.reporter.JUnit4TestReporter")
       )
-    else Seq(Tests.Argument("-oDF"))
+    else Seq(Tests.Argument(TestFrameworks.JUnit, "-v"), Tests.Argument("-oDF"))
 
   val MaybeCoverage: Plugins = if (enableCoverage) Coverage else Plugins.empty
   val jsTestArg              = Test / testOptions := Seq(Tests.Argument("-oDF"))
@@ -65,6 +66,7 @@ object Common {
     // and the maven repo match
     version := sys.env.getOrElse("JITPACK_VERSION", "0.1.0-SNAPSHOT"),
     fork    := true,
+    Test / fork := true,
     Test / javaOptions ++= Seq("-Dakka.actor.serialize-messages=on"),
     autoCompilerPlugins     := true,
     Global / cancelable     := true, // allow ongoing test(or any task) to cancel with ctrl + c and still remain inside sbt

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
       AkkaHttp.`akka-http-spray-json`, // akka-cluster-management uses lower version, to avoid conflict, this needs to be overridden
       MSocket.`msocket-http`,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-13`               % Test,
+      Libs.`junit4-interface`         % Test,
       Libs.`mockito`                  % Test,
       Akka.`akka-actor-testkit-typed` % Test,
       Libs.`jboss-logging`            % Test,
@@ -52,8 +52,8 @@ object Dependencies {
       Libs.`scala-async`,
       Libs.`scala-java8-compat`,
       MSocket.`msocket-http`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test
     )
   )
 
@@ -119,9 +119,9 @@ object Dependencies {
       AkkaHttp.`akka-http`,
       Libs.`scala-async`,
       Libs.`scala-java8-compat`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test,
-      Libs.`mockito`         % Test
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test,
+      Libs.`mockito`          % Test
     )
   )
 
@@ -154,8 +154,8 @@ object Dependencies {
       Libs.`enumeratum`.value,
       Akka.`akka-actor`,
       Akka.`akka-actor-typed`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test,
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test,
       Borer.`borer-core`.value,
       Libs.`gson` % Test
     )
@@ -182,7 +182,7 @@ object Dependencies {
   val ParamsJvm = Def.setting(
     Seq(
       Libs.`play-json`,
-      Libs.`junit-4-13` % Test
+      Libs.`junit4-interface` % Test
     )
   )
 
@@ -201,7 +201,7 @@ object Dependencies {
       Akka.`akka-actor-testkit-typed` % Test,
       Akka.`akka-stream-testkit`      % Test,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-13`               % Test,
+      Libs.`junit4-interface`         % Test,
       Libs.`mockito`                  % Test
     )
   )
@@ -223,7 +223,7 @@ object Dependencies {
       Akka.`akka-actor-testkit-typed` % Test,
       Akka.`akka-stream-testkit`      % Test,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-13`               % Test,
+      Libs.`junit4-interface`         % Test,
       Libs.`mockito`                  % Test
     )
   )
@@ -262,7 +262,7 @@ object Dependencies {
       Akka.`akka-multi-node-testkit`  % Test,
       Akka.`akka-actor-testkit-typed` % Test,
       Libs.`scalatest`.value          % Test,
-      Libs.`junit-4-13`               % Test,
+      Libs.`junit4-interface`         % Test,
       Libs.`mockito`                  % Test,
       Libs.`embedded-redis`           % Test,
       Libs.`embedded-kafka`           % Test,
@@ -317,9 +317,9 @@ object Dependencies {
       Akka.`akka-actor-typed`,
       Akka.`akka-stream`,
       Akka.`akka-stream-typed`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test,
-      Libs.`mockito`         % Test
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test,
+      Libs.`mockito`          % Test
     )
   )
 
@@ -354,7 +354,7 @@ object Dependencies {
       Libs.`scalatest`.value,
       Libs.`embedded-redis`,
       Libs.`io.zonky.test`,
-      Libs.`junit-4-13`,
+      Libs.`junit4-interface`,
       Libs.`mockito`
     )
   )
@@ -362,8 +362,8 @@ object Dependencies {
   val TimeClockJvm = Def.setting(
     Seq(
       Libs.`jna`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test
     )
   )
 
@@ -387,10 +387,10 @@ object Dependencies {
       Jooq.`jooq`,
       Jooq.`jooq-meta`,
       Jooq.`jooq-codegen`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test,
-      Akka.`akka-actor`      % Test,
-      Libs.`io.zonky.test` % Test
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test,
+      Akka.`akka-actor`       % Test,
+      Libs.`io.zonky.test`    % Test
     )
   )
 
@@ -484,8 +484,8 @@ object Dependencies {
       AkkaHttp.`akka-http`,
       AkkaHttp.`akka-http-cors`,
       Akka.`akka-actor-testkit-typed`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test
     )
   )
 
@@ -502,15 +502,15 @@ object Dependencies {
       Jackson.`jackson-core`,
       Jackson.`jackson-databind`,
       Akka.`akka-actor-testkit-typed`,
-      Libs.`scalatest`.value % Test,
-      Libs.`junit-4-13`      % Test
+      Libs.`scalatest`.value  % Test,
+      Libs.`junit4-interface` % Test
     )
   )
 
   val Integration = Def.setting(
     Seq(
       Libs.`scalatest`.value,
-      Libs.`junit-4-13`,
+      Libs.`junit4-interface`,
       Libs.`mockito`,
       Akka.`akka-actor`,
       Akka.`akka-actor-typed`,

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -53,7 +53,7 @@ object Libs {
   val `caffeine`          = "com.github.ben-manes.caffeine" % "caffeine"          % "3.0.5"
   val netty               = "io.netty"                      % "netty-all"         % "4.1.73.Final"
   val `case-app`          = "com.github.alexarchambault"   %% "case-app"          % "2.0.6"
-  val `tmt-test-reporter` = "com.github.tmtsoftware"       %% "rtm"               % "cfc4dd7"
+  val `tmt-test-reporter` = "com.github.tmtsoftware"       %% "rtm"               % "eb9092b"
 }
 
 object Borer {

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -31,13 +31,13 @@ object Libs {
   val `reactive-streams` = "org.reactivestreams" % "reactive-streams" % "1.0.3"
   val `akka-stream-kafka` =
     "com.typesafe.akka" %% "akka-stream-kafka" % "2.1.0" // 2.1.1 version is breaking csw-event-client tests
-  val `embedded-kafka` = "io.github.embeddedkafka" %% "embedded-kafka" % "3.0.0"
-  val `embedded-redis` = "com.github.kstyrc"        % "embedded-redis" % "0.6"
-  val `scala-compiler` = "org.scala-lang"           % "scala-compiler" % ScalaVersion
-  val `HdrHistogram`   = "org.hdrhistogram"         % "HdrHistogram"   % "2.1.12"
-  val `testng`         = "org.testng"               % "testng"         % "7.5.0"
-  val `junit-4-13`     = "org.scalatestplus"       %% "junit-4-13"     % "3.2.10.0"
-  val `testng-6-7`     = "org.scalatestplus"       %% "testng-6-7"     % "3.2.10.0"
+  val `embedded-kafka`   = "io.github.embeddedkafka" %% "embedded-kafka"  % "3.0.0"
+  val `embedded-redis`   = "com.github.kstyrc"        % "embedded-redis"  % "0.6"
+  val `scala-compiler`   = "org.scala-lang"           % "scala-compiler"  % ScalaVersion
+  val `HdrHistogram`     = "org.hdrhistogram"         % "HdrHistogram"    % "2.1.12"
+  val `testng`           = "org.testng"               % "testng"          % "7.5.0"
+  val `junit4-interface` = "com.github.sbt"           % "junit-interface" % "0.13.2"
+  val `testng-6-7`       = "org.scalatestplus"       %% "testng-6-7"      % "3.2.10.0"
 
   val `scala-csv`             = "com.github.tototoshi" %% "scala-csv"             % "1.3.10"
   val `json-schema-validator` = "com.github.fge"        % "json-schema-validator" % "2.2.14" // LGPL/ASL
@@ -53,7 +53,7 @@ object Libs {
   val `caffeine`          = "com.github.ben-manes.caffeine" % "caffeine"          % "3.0.5"
   val netty               = "io.netty"                      % "netty-all"         % "4.1.73.Final"
   val `case-app`          = "com.github.alexarchambault"   %% "case-app"          % "2.0.6"
-  val `tmt-test-reporter` = "com.github.tmtsoftware"       %% "rtm"               % "0.3.0"
+  val `tmt-test-reporter` = "com.github.tmtsoftware"       %% "rtm"               % "63cd5fcf93"
 }
 
 object Borer {

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -53,7 +53,7 @@ object Libs {
   val `caffeine`          = "com.github.ben-manes.caffeine" % "caffeine"          % "3.0.5"
   val netty               = "io.netty"                      % "netty-all"         % "4.1.73.Final"
   val `case-app`          = "com.github.alexarchambault"   %% "case-app"          % "2.0.6"
-  val `tmt-test-reporter` = "com.github.tmtsoftware"       %% "rtm"               % "63cd5fcf93"
+  val `tmt-test-reporter` = "com.github.tmtsoftware"       %% "rtm"               % "cfc4dd7"
 }
 
 object Borer {


### PR DESCRIPTION
…terface for junit4 tests

While working on documentation story, we encountered few java tests were getting skipped because JUnitSuite( marker from ScalaTest) was not failing in case of any error in BeforeClass setup for java tests.

Currently, we have 1 test runner for both scala & java tests which is coming from ScalaTest framework. The runner provided by ScalaTestPlus+Junit has an issue. Whenever there is an exception in @BeforeClass it doesn’t fail instead it skips the tests in that class without showing any log.

This PR is created to resolve that issue.
This PR also makes sure all java tests are properly running now & the error like above gets caught in future.